### PR TITLE
insert cloud watch events into the database

### DIFF
--- a/lib/cloud-watch-event-listener.js
+++ b/lib/cloud-watch-event-listener.js
@@ -105,6 +105,12 @@ class CloudWatchEventListener extends events.EventEmitter {
     let id = body.detail['instance-id'];
     let state = body.detail.state;
 
+    try {
+      await this.state.logCloudWatch({region, id, state});
+    } catch (err) {
+      // We don't want to block things
+      this.monitor.reportError(err);
+    }
 
     if (state === 'pending' || state === 'running') {
       let apiResponse;

--- a/lib/state.js
+++ b/lib/state.js
@@ -81,6 +81,35 @@ class State {
   }
 
   /**
+   * Insert a spot request.
+   */
+  async insertSpotRequest({workerType, region, instanceType, id, state, status}, client) {
+    assert(typeof workerType === 'string');
+    assert(typeof region === 'string');
+    assert(typeof instanceType === 'string');
+    assert(typeof id === 'string');
+    assert(typeof state === 'string');
+    assert(typeof status === 'string');
+
+    let text = [
+      "INSERT INTO spotrequests (id, workerType, region, instanceType, state, status)",
+      "VALUES ($1, $2, $3, $4, $5, $6)"
+    ].join(' ');
+    let values = [id, workerType, region, instanceType, state, status];
+    let name = 'insert-spot-request';
+
+    let result;
+    if (client) {
+      log.info('inserting spot request using a provided client object (not releasing)');
+      result = await client.query({text, values, name});
+    } else {
+      log.info('inserting spot request using Pool.query');
+      result = await this._pgpool.query({text, values, name});
+    }
+    assert(result.rowCount === 1, 'inserting spot request had incorrect rowCount');
+  }
+
+  /**
    * Either insert or update a spot request.  This ensures an atomic insert or
    * update, but we never learn which one happened.
    */
@@ -111,35 +140,6 @@ class State {
   }
 
   /**
-   * Insert a spot request.
-   */
-  async insertSpotRequest({workerType, region, instanceType, id, state, status}, client) {
-    assert(typeof workerType === 'string');
-    assert(typeof region === 'string');
-    assert(typeof instanceType === 'string');
-    assert(typeof id === 'string');
-    assert(typeof state === 'string');
-    assert(typeof status === 'string');
-
-    let text = [
-      "INSERT INTO spotrequests (id, workerType, region, instanceType, state, status)",
-      "VALUES ($1, $2, $3, $4, $5, $6)"
-    ].join(' ');
-    let values = [id, workerType, region, instanceType, state, status];
-    let name = 'insert-spot-request';
-
-    let result;
-    if (client) {
-      log.info('inserting spot request using a provided client object (not releasing)');
-      result = await client.query({text, values, name});
-    } else {
-      log.info('inserting spot request using Pool.query');
-      result = await this._pgpool.query({text, values, name});
-    }
-    assert(result.rowCount === 1, 'inserting spot request had incorrect rowCount');
-  }
-
-  /**
    * Update a spot request's state.
    */
   async updateSpotRequestState({region, id, state, status}, client) {
@@ -163,25 +163,23 @@ class State {
   }
 
   /**
-   * Update an instance's state.
+   * Stop tracking a spot request.
    */
-  async updateInstanceState({region, id, state}, client) {
+  async removeSpotRequest({region, id}, client) {
     assert(typeof region === 'string');
     assert(typeof id === 'string');
-    assert(typeof state === 'string');
 
-    let text = "UPDATE instances SET state = $1 WHERE region = $2 AND id = $3";
-    let values = [state, region, id];
-    let name = 'update-instance-state';
-    
+    let text = "DELETE FROM spotrequests WHERE id = $1 AND region = $2";
+    let values = [id, region];
+
     let result;
     if (client) {
-      result = await client.query({text, values, name});
+      result = await client.query({text, values});
     } else {
-      result = await this._pgpool.query({text, values, name});
+      result = await this._pgpool.query({text, values, name: 'remove-spot-request'});
     }
 
-    assert(result.rowCount === 1, 'updating instance state had incorrect rowCount');
+    return result.rowCount;
   }
 
   /**
@@ -299,23 +297,25 @@ class State {
   }
 
   /**
-   * Stop tracking a spot request.
+   * Update an instance's state.
    */
-  async removeSpotRequest({region, id}, client) {
+  async updateInstanceState({region, id, state}, client) {
     assert(typeof region === 'string');
     assert(typeof id === 'string');
+    assert(typeof state === 'string');
 
-    let text = "DELETE FROM spotrequests WHERE id = $1 AND region = $2";
-    let values = [id, region];
-
+    let text = "UPDATE instances SET state = $1 WHERE region = $2 AND id = $3";
+    let values = [state, region, id];
+    let name = 'update-instance-state';
+    
     let result;
     if (client) {
-      result = await client.query({text, values});
+      result = await client.query({text, values, name});
     } else {
-      result = await this._pgpool.query({text, values, name: 'remove-spot-request'});
+      result = await this._pgpool.query({text, values, name});
     }
 
-    return result.rowCount;
+    assert(result.rowCount === 1, 'updating instance state had incorrect rowCount');
   }
 
   /**

--- a/lib/state.js
+++ b/lib/state.js
@@ -100,10 +100,8 @@ class State {
 
     let result;
     if (client) {
-      log.info('inserting spot request using a provided client object (not releasing)');
       result = await client.query({text, values, name});
     } else {
-      log.info('inserting spot request using Pool.query');
       result = await this._pgpool.query({text, values, name});
     }
     assert(result.rowCount === 1, 'inserting spot request had incorrect rowCount');
@@ -568,6 +566,27 @@ class State {
         client.release();
       }
     }
+  }
+
+  async logCloudWatchEvent({region, id, state}, client) {
+    assert(typeof region === 'string');
+    assert(typeof id === 'string');
+    assert(typeof state === 'string');
+
+    let text = [
+      "INSERT INTO cloudwatchlog (id, region, state)",
+      "VALUES ($1, $2, $3)"
+    ].join(' ');
+    let values = [id, region, state];
+    let name = 'insert-cloud-watch-log';
+
+    let result;
+    if (client) {
+      result = await client.query({text, values, name});
+    } else {
+      result = await this._pgpool.query({text, values, name});
+    }
+    assert(result.rowCount === 1, 'inserting spot request had incorrect rowCount');
   }
   
   /**

--- a/sql/clear-db.sql
+++ b/sql/clear-db.sql
@@ -1,3 +1,4 @@
 -- Clear out the database from all entries
 DELETE FROM spotrequests;
 DELETE FROM instances;
+DELETE FROM cloudwatchlog;

--- a/sql/create-db.sql
+++ b/sql/create-db.sql
@@ -66,11 +66,12 @@ CREATE TRIGGER update_instances_touched
 BEFORE UPDATE ON instances
 FOR EACH ROW EXECUTE PROCEDURE update_touched();
 
-
--- Here's a couple of inserts which will work with
--- these queries:
---INSERT INTO spotrequests (id, workerType, region, instanceType, state, status)
---VALUES ('r-1234', 'test-workertype', 'us-east-1', 'm3.xlarge', 'open', 'pending-fulfillment');
-
---INSERT INTO instances (id, workerType, region, instanceType, state, srid)
---VALUES ('i-1235', 'test-workertype', 'us-east-1', 'm3.xlarge', 'running', 'r-1234');
+-- Cloudwatch Events Log
+-- We want to keep a log of when every cloud watch event was received
+CREATE TABLE IF NOT EXISTS cloudwatchlog (
+  region VARCHAR(128), -- ec2 region
+  id VARCHAR(128), -- opaque ID per amazon
+  state VARCHAR(128), -- state from message
+  received TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (id, region, state, received)
+);

--- a/sql/drop-db.sql
+++ b/sql/drop-db.sql
@@ -4,4 +4,5 @@ DROP TRIGGER IF EXISTS update_spotrequests_touched ON spotrequests;
 DROP TRIGGER IF EXISTS update_instances_touched ON instances;
 DROP TABLE IF EXISTS spotrequests;
 DROP TABLE IF EXISTS instances;
+DROP TABLE IF EXISTS cloudwatchlog;
 DROP FUNCTION IF EXISTS update_touched();

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -136,7 +136,9 @@ describe('Api', () => {
 
       let requests = await state.listSpotRequests();
       assume(requests).has.lengthOf(1);
-      assume(runaws.callCount).equals(1);
+      assume(runaws.callCount).equals(2);
+      assume(runaws.args[0][1]).equals('requestSpotInstances');
+      assume(runaws.args[1][1]).equals('createTags');
       let call = runaws.firstCall.args;
       assume(call[0].config.region).equals(region);
       assume(call[1]).equals('requestSpotInstances');
@@ -157,8 +159,9 @@ describe('Api', () => {
       });
       requests = await state.listSpotRequests();
       assume(requests).has.lengthOf(1);
-      assume(runaws.callCount).equals(1);
- 
+      assume(runaws.callCount).equals(2);
+      assume(runaws.args[0][1]).equals('requestSpotInstances');
+      assume(runaws.args[1][1]).equals('createTags');
     });
   });
 

--- a/test/state_test.js
+++ b/test/state_test.js
@@ -308,4 +308,15 @@ describe('State', () => {
     assume(expected).deeply.equals(actual);
   });
 
+  it('should log cloud watch events', async () => {
+    await db.logCloudWatchEvent({region, id: 'i-1', state: 'pending'});
+    let client = await db.getClient();
+    let result = await client.query('select * from cloudwatchlog');
+    assume(result.rows).has.lengthOf(1);
+    let row = result.rows[0];
+    assume(row).has.property('region', region);
+    assume(row).has.property('id', 'i-1');
+    assume(row).has.property('state', 'pending');
+  });
+
 });


### PR DESCRIPTION
This is mainly for debugging right now, but it is an interesting data set which we might be able to use later.  Currently the table only has instance id, region, state and the time the event was received, but could be expanded upon later