### PR TITLE
Run housekeeping in its own dyno

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: node lib/main start | ./node_modules/.bin/bunyan -o short
+housekeeper: node lib/main starthk | ./node_modules/.bin/bunyan -o short

--- a/lib/main.js
+++ b/lib/main.js
@@ -294,13 +294,20 @@ let load = loader({
     }
   },
 
+  starthk: {
+    requires: ['housekeeper'],
+    setup: async ({housekeeper}) => {
+      housekeeper.start();
+    },
+  },
+
   start: {
-    requires: ['eventlisteners', 'deadeventlisteners', 'server', 'spotpollers', 'housekeeper'],
-    setup: async ({eventlisteners, deadeventlisteners, server, spotpollers, housekeeper}) => {
+    requires: ['eventlisteners', 'deadeventlisteners', 'server', 'spotpollers'/*, 'housekeeper'*/],
+    setup: async ({eventlisteners, deadeventlisteners, server, spotpollers/*, housekeeper*/}) => {
       eventlisteners.map(x => x.start());
       deadeventlisteners.map(x => x.start());
       spotpollers.map(x => x.start());
-      housekeeper.start();
+      //housekeeper.start();
       log.info('Started');
     },
   },


### PR DESCRIPTION
This makes it easier to see the outcome of this as I can see the logs of *just* house keeping without worrying that a grep/search criteria is filtering out too much