### PR TITLE
allow manage-worker-type permissions to run terminateInstance()

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -409,15 +409,26 @@ api.declare({
   name: 'terminateInstance',
   title: 'Terminate an instance',
   stability: API.stability.experimental,
-  scopes: [['ec2-manager:manage-instances:<region>:<instanceId>']],
+  scopes: [
+    ['ec2-manager:manage-instances:<region>:<instanceId>'],
+    ['ec2-manager:manage-worker-type:<workerType>'],
+  ],
   description: [
     'Terminate an instance in a specified region',
   ].join(' '),
 }, async function (req, res) {
   let region = req.params.region;
   let instanceId = req.params.instanceId;
+  let workerType;
 
-  if (!req.satisfies({region, instanceId})) { return undefined; }
+  // We'll try to see if there's a worker type known for this instance id in
+  // the specified region.  If the instance does exist, we'll use the worker
+  // type that it's assigned to to check permissions
+  try {
+    workerType = await this.state.listInstances({region, id: instanceId});
+  } catch (err) { }
+
+  if (!req.satisfies({region, instanceId, workerType})) { return undefined; }
 
   if (!this.regions.includes(region)) {
     res.reportError('ResourceNotFound', 'Region is not configured', {});
@@ -456,15 +467,26 @@ api.declare({
   name: 'cancelSpotInstanceRequest',
   title: 'Cancel a request for a spot instance',
   stability: API.stability.experimental,
-  scopes: [['ec2-manager:manage-spot-requests:<region>:<requestId>']],
+  scopes: [
+    ['ec2-manager:manage-spot-requests:<region>:<requestId>'],
+    ['ec2-manager:manage-worker-type:<workerType>'],
+  ],
   description: [
     'Cancel a spot instance request in a region',
   ].join(' '),
 }, async function (req, res) {
   let region = req.params.region;
   let requestId = req.params.requestId;
+  let workerType;
 
-  if (!req.satisfies({region, requestId})) { return undefined; }
+  // We'll try to see if there's a worker type known for this request id in
+  // the specified region.  If the instance does exist, we'll use the worker
+  // type that it's assigned to to check permissions
+  try {
+    workerType = await this.state.listInstances({region, id: requestId});
+  } catch (err) { }
+
+  if (!req.satisfies({region, requestId, workerType})) { return undefined; }
 
   if (!this.regions.includes(region)) {
     res.reportError('ResourceNotFound', 'Region is not configured', {});


### PR DESCRIPTION
So the idea here is to allow someone to kill an instance based on a per-workertype scope instead of allowing an all-or-nothing approach.  The downside here is that we have to do a DB query to determine whether the request is allowed or not, but I think this should be OK.

My concern is mainly about the behaviour of passing in an undefined value into the req.satisfies method.

This should help @helfi92 implement the kill instance action.