### PR TITLE
Create sweepVolumes method to fetch and process EBS volumes data

### DIFF
--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -40,7 +40,7 @@ class HouseKeeper {
 
   async handleVolumeData(volume) {}
 
-  async sweepVolumes() {
+  async sweepVolumes(region) {
     let volumes = await this.runaws(this.ec2[region], 'describeVolumes', {
       Filters: [{
         Name: 'status',
@@ -48,9 +48,7 @@ class HouseKeeper {
       }],
     });
 
-    for (let volume of volumes.Volumes) {
-      handleVolumeData(volume);
-    }
+    await Promise.all(volumes.Volumes.map(this.handleVolumeData));
   }
 
   async sweep() {
@@ -82,7 +80,7 @@ class HouseKeeper {
       let stateInstanceIds = stateInstances.map(x => x.id);
       let stateRequestIds = stateRequests.map(x => x.id);
 
-      sweepVolumes();
+      await this.sweepVolumes(region);
 
       let instances = await this.runaws(this.ec2[region], 'describeInstances', {
         Filters: [{

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -36,24 +36,19 @@ class HouseKeeper {
     this.maxInstanceLifeHours = maxInstanceLifeHours;
     this.monitor = monitor;
     this.tagger = tagger;
+  }
 
-    this.describeVolumesParams =  {
+  async _handleVolumeData(volume) {}
+
+  async _sweepVolumes(region) {
+    let volumes = await this.runaws(this.ec2[region], 'describeVolumes', {
       Filters: [{
         Name: 'status',
         Values: ['available', 'in-use'],
       }],
-    } 
-  }
+    });
 
-  async handleVolumeData(volume) {}
-
-  async sweepVolumes(region) {
-    let volumes = await this.runaws(
-      this.ec2[region],
-      'describeVolumes',
-      this.describeVolumesParams);
-
-    await Promise.all(volumes.Volumes.map(this.handleVolumeData));
+    await Promise.all(volumes.Volumes.map(this._handleVolumeData));
   }
 
   async sweep() {
@@ -85,7 +80,7 @@ class HouseKeeper {
       let stateInstanceIds = stateInstances.map(x => x.id);
       let stateRequestIds = stateRequests.map(x => x.id);
 
-      await this.sweepVolumes(region);
+      await this._sweepVolumes(region);
 
       let instances = await this.runaws(this.ec2[region], 'describeInstances', {
         Filters: [{

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -38,9 +38,24 @@ class HouseKeeper {
     this.tagger = tagger;
   }
 
+  async handleVolumeData(volume) {}
+
+  async sweepVolumes() {
+    let volumes = await this.runaws(this.ec2[region], 'describeVolumes', {
+      Filters: [{
+        Name: 'status',
+        Values: ['available', 'in-use'],
+      }],
+    });
+
+    for (let volume of volumes.Volumes) {
+      handleVolumeData(volume);
+    }
+  }
+
   async sweep() {
     log.info('starting housekeeping');
-    
+
     /* A Zombie is considered to be an instance which has lived for too long.
      * These instances are often long living because they've forgotten to shut
      * themselves down.  When that happens, we could end up spending a lot of
@@ -66,6 +81,8 @@ class HouseKeeper {
       let stateRequests = await this.state.listSpotRequests({region});
       let stateInstanceIds = stateInstances.map(x => x.id);
       let stateRequestIds = stateRequests.map(x => x.id);
+
+      sweepVolumes();
 
       let instances = await this.runaws(this.ec2[region], 'describeInstances', {
         Filters: [{
@@ -204,7 +221,7 @@ class HouseKeeper {
             az,
             created,
             imageId,
-          }); 
+          });
           this.monitor.count('state.request-missing-from-state.global', 1);
           this.monitor.count(`state.request-missing-from-state.${region}`, 1);
           missingRequests++;
@@ -233,9 +250,9 @@ class HouseKeeper {
           workerTypes[resource.workerType].push(resource.id);
         } else {
           workerTypes[resource.workerType] = [resource.id];
-        } 
+        }
       }
-      
+
       // Now do all the tagging
       for (let workerType of Object.keys(workerTypes)) {
         await this.tagger.tagResources({

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -36,17 +36,22 @@ class HouseKeeper {
     this.maxInstanceLifeHours = maxInstanceLifeHours;
     this.monitor = monitor;
     this.tagger = tagger;
+
+    this.describeVolumesParams =  {
+      Filters: [{
+        Name: 'status',
+        Values: ['available', 'in-use'],
+      }],
+    } 
   }
 
   async handleVolumeData(volume) {}
 
   async sweepVolumes(region) {
-    let volumes = await this.runaws(this.ec2[region], 'describeVolumes', {
-      Filters: [{
-        Name: 'status',
-        Values: ['available', 'in-use'],
-      }],
-    });
+    let volumes = await this.runaws(
+      this.ec2[region],
+      'describeVolumes',
+      this.describeVolumesParams);
 
     await Promise.all(volumes.Volumes.map(this.handleVolumeData));
   }

--- a/test/housekeeping_test.js
+++ b/test/housekeeping_test.js
@@ -401,28 +401,38 @@ describe('House Keeper', () => {
       SpotInstanceRequests: [
       ]
     });
-    
+
+    describeVolumesStub.withArgs(ec2[region], 'describeVolumes', houseKeeper.describeVolumesParams)
+      .returns({
+        Volumes: [{
+          Attachments: [],
+          AvailabilityZone: region, 
+          CreateTime: new Date().toString(), 
+          Size: 8, 
+          SnapshotId: "snap-1234567890abcdef0", 
+          State: "in-use", 
+          VolumeId: "vol-049df61146c4d7901", 
+          VolumeType: "standard",
+        }]
+      });
+
+    describeVolumesStub.withArgs(ec2['us-east-2'], 'describeVolumes', houseKeeper.describeVolumesParams)
+      .returns({
+        Volumes: [{
+          Attachments: [], 
+          AvailabilityZone: 'us-east-2', 
+          CreateTime: new Date().toString(), 
+          Size: 16, 
+          SnapshotId: "snap-1234567890abcdef09", 
+          State: "in-use", 
+          VolumeId: "vol-049df61146c4d7902", 
+          VolumeType: "standard",
+        }]
+      });
+
     describeVolumesStub.returns({
-      Volumes: [{
-        Attachments: [],
-        AvailabilityZone: region, 
-        CreateTime: new Date().toString(), 
-        Size: 8, 
-        SnapshotId: "snap-1234567890abcdef0", 
-        State: "in-use", 
-        VolumeId: "vol-049df61146c4d7901", 
-        VolumeType: "standard",
-      },
-      {
-        Attachments: [], 
-        AvailabilityZone: 'us-east-2', 
-        CreateTime: new Date().toString(), 
-        Size: 16, 
-        SnapshotId: "snap-1234567890abcdef09", 
-        State: "in-use", 
-        VolumeId: "vol-049df61146c4d7902", 
-        VolumeType: "standard",
-      }]
+      Volumes: [
+      ]
     });
       
     await houseKeeper.sweep();

--- a/test/housekeeping_test.js
+++ b/test/housekeeping_test.js
@@ -352,7 +352,7 @@ describe('House Keeper', () => {
   });
 
   it('should call sweepVolumes exactly once', async() => {
-    houseKeeperMock.expects("sweepVolumes").exactly(regions.length);
+    houseKeeperMock.expects("_sweepVolumes").exactly(regions.length);
     
     describeInstancesStub.returns({
       Reservations: [
@@ -369,7 +369,7 @@ describe('House Keeper', () => {
   });
 
   it('should not fail if no volume data is returned', async() => {
-    houseKeeperMock.expects("handleVolumeData").never();
+    houseKeeperMock.expects("_handleVolumeData").never();
     describeInstancesStub.returns({
       Reservations: [
       ]
@@ -389,8 +389,8 @@ describe('House Keeper', () => {
     houseKeeperMock.verify();
   });
   
-  it('should call handleVolumeData once per volume', async() => {
-    houseKeeperMock.expects("handleVolumeData").twice();
+  it('should call handleVolumeData exactly once per volume', async() => {
+    houseKeeperMock.expects("_handleVolumeData").twice();
       
     describeInstancesStub.returns({
       Reservations: [
@@ -402,33 +402,35 @@ describe('House Keeper', () => {
       ]
     });
 
-    describeVolumesStub.withArgs(ec2[region], 'describeVolumes', houseKeeper.describeVolumesParams)
-      .returns({
-        Volumes: [{
-          Attachments: [],
-          AvailabilityZone: region, 
-          CreateTime: new Date().toString(), 
-          Size: 8, 
-          SnapshotId: "snap-1234567890abcdef0", 
-          State: "in-use", 
-          VolumeId: "vol-049df61146c4d7901", 
-          VolumeType: "standard",
-        }]
-      });
+    describeVolumesStub.withArgs(sinon.match(function(value) {
+      return value === ec2['us-west-2'] 
+    })).returns({
+       Volumes: [{
+         Attachments: [],
+         AvailabilityZone: 'us-west-2', 
+         CreateTime: new Date().toString(), 
+         Size: 8, 
+         SnapshotId: "snap-1234567890abcdef0", 
+         State: "in-use", 
+         VolumeId: "vol-049df61146c4d7901", 
+         VolumeType: "standard",
+       }]
+    });
 
-    describeVolumesStub.withArgs(ec2['us-east-2'], 'describeVolumes', houseKeeper.describeVolumesParams)
-      .returns({
-        Volumes: [{
-          Attachments: [], 
-          AvailabilityZone: 'us-east-2', 
-          CreateTime: new Date().toString(), 
-          Size: 16, 
-          SnapshotId: "snap-1234567890abcdef09", 
-          State: "in-use", 
-          VolumeId: "vol-049df61146c4d7902", 
-          VolumeType: "standard",
-        }]
-      });
+    describeVolumesStub.withArgs(sinon.match(function(value) {
+      return value === ec2['us-east-2']
+    })).returns({
+      Volumes: [{
+        Attachments: [], 
+        AvailabilityZone: 'us-east-2', 
+        CreateTime: new Date().toString(), 
+        Size: 16, 
+        SnapshotId: "snap-1234567890abcdef09", 
+        State: "in-use", 
+        VolumeId: "vol-049df61146c4d7902", 
+        VolumeType: "standard",
+      }]
+    });
 
     describeVolumesStub.returns({
       Volumes: [

--- a/test/housekeeping_test.js
+++ b/test/housekeeping_test.js
@@ -44,6 +44,7 @@ describe('House Keeper', () => {
 
     describeInstancesStub = sandbox.stub();
     describeSpotInstanceRequestsStub = sandbox.stub();
+    describeVolumesStub = sandbox.stub();
     terminateInstancesStub = sandbox.stub();
     createTagsStub = sandbox.stub();
 
@@ -52,6 +53,8 @@ describe('House Keeper', () => {
         return describeInstancesStub(service, method, params);
       } else if (method === 'describeSpotInstanceRequests') {
         return describeSpotInstanceRequestsStub(service, method, params);
+      } else if (method === 'describeVolumes') {
+        return describeVolumesStub(service, method, params);
       } else if (method === 'terminateInstances') {
         return terminateInstancesStub(service, method, params);
       } else if (method === 'createTags') {
@@ -323,5 +326,13 @@ describe('House Keeper', () => {
       });
     }
   });
-});
 
+  it('should not fail if no volume data is returned', async() => {
+    describeVolumesStub.returns({
+      Volumes: [
+      ]
+    });
+
+    let outcome = await houseKeeper.sweep();
+  });
+});

--- a/test/housekeeping_test.js
+++ b/test/housekeeping_test.js
@@ -50,6 +50,24 @@ describe('House Keeper', () => {
     terminateInstancesStub = sandbox.stub();
     createTagsStub = sandbox.stub();
 
+    // Since many of the tests will not need to specify custom input, we can set the default
+    // behaviour of these stubs as returning empty objects. This way, only custom return statements
+    // need to be specified in any of the tests.
+    describeInstancesStub.returns({
+      Reservations: [{
+        Instances: [
+        ],
+      }]
+    });
+    describeSpotInstanceRequestsStub.returns({
+      SpotInstanceRequests: [
+      ]
+    });
+    describeVolumesStub.returns({
+       Volumes: [
+       ],
+    });
+
     async function runaws(service, method, params) {
       if (method === 'describeInstances') {
         return describeInstancesStub(service, method, params);
@@ -78,7 +96,7 @@ describe('House Keeper', () => {
       tagger,
     });
     
-     houseKeeperMock = sandbox.mock(houseKeeper);
+    houseKeeperMock = sandbox.mock(houseKeeper);
   });
 
   afterEach(() => {
@@ -114,23 +132,6 @@ describe('House Keeper', () => {
 
     assume(await state.listInstances()).has.lengthOf(2);
     assume(await state.listSpotRequests()).has.lengthOf(2);
-
-    describeInstancesStub.returns({
-      Reservations: [{
-        Instances: [
-        ],
-      }]
-    });
-
-    describeSpotInstanceRequestsStub.returns({
-      SpotInstanceRequests: [
-      ]
-    });
-
-    describeVolumesStub.returns({
-      Volumes: [
-      ]
-    });
 
     let outcome = await houseKeeper.sweep();
     assume(await state.listInstances()).has.lengthOf(0);
@@ -186,11 +187,6 @@ describe('House Keeper', () => {
           Code: 'pending-evaluation',
         },
       }]
-    });
-
-    describeVolumesStub.returns({
-      Volumes: [
-      ]
     });
 
     let outcome = await houseKeeper.sweep();
@@ -249,11 +245,6 @@ describe('House Keeper', () => {
           Code: 'pending-evaluation',
         },
       }]
-    });
-
-    describeVolumesStub.returns({
-      Volumes: [
-      ]
     });
 
     let outcome = await houseKeeper.sweep();
@@ -318,15 +309,6 @@ describe('House Keeper', () => {
       }]
     });
 
-    describeSpotInstanceRequestsStub.returns({
-      SpotInstanceRequests: []
-    });
-
-    describeVolumesStub.returns({
-      Volumes: [
-      ]
-    });
-
     let outcome = await houseKeeper.sweep();
     // Because we're returning the same thing for all regions, we need to check
     // that we've got one for each region
@@ -354,36 +336,12 @@ describe('House Keeper', () => {
   it('should call sweepVolumes exactly once', async() => {
     houseKeeperMock.expects("_sweepVolumes").exactly(regions.length);
     
-    describeInstancesStub.returns({
-      Reservations: [
-      ]
-    });
-    
-    describeSpotInstanceRequestsStub.returns({
-      SpotInstanceRequests: [
-      ]
-    });
-    
     await houseKeeper.sweep();
     houseKeeperMock.verify();
   });
 
   it('should not fail if no volume data is returned', async() => {
     houseKeeperMock.expects("_handleVolumeData").never();
-    describeInstancesStub.returns({
-      Reservations: [
-      ]
-    });
-    
-    describeSpotInstanceRequestsStub.returns({
-      SpotInstanceRequests: [
-      ]
-    });
-    
-    describeVolumesStub.returns({
-      Volumes: [
-      ]
-    });
 
     await houseKeeper.sweep();
     houseKeeperMock.verify();
@@ -392,16 +350,6 @@ describe('House Keeper', () => {
   it('should call handleVolumeData exactly once per volume', async() => {
     houseKeeperMock.expects("_handleVolumeData").twice();
       
-    describeInstancesStub.returns({
-      Reservations: [
-      ]
-    });
-    
-    describeSpotInstanceRequestsStub.returns({
-      SpotInstanceRequests: [
-      ]
-    });
-
     describeVolumesStub.withArgs(sinon.match(function(value) {
       return value === ec2['us-west-2'] 
     })).returns({
@@ -432,11 +380,7 @@ describe('House Keeper', () => {
       }]
     });
 
-    describeVolumesStub.returns({
-      Volumes: [
-      ]
-    });
-      
+     
     await houseKeeper.sweep();
     houseKeeperMock.verify();
    });


### PR DESCRIPTION
We implemented the recommended changes from Samantha's earlier pull request:
* Call sweepVolumes with the await operator
* Encapsulate calls to handleVolumeData within Promise.all(...)

In addition, we added 3 unit tests for the new method, sweepVolumes:
1. Mock sweepVolumes to ensure that it is actually called by sweep()
2. Test that sweepVolumes can handle receiving an empty dataset from AWS. Since the previous test verifies that sweepVolumes is being called by sweep(), we simply run sweep() with an appropriate return value from the describeVolumesStub.
3. Test that sweepVolumes calls handleVolumeData only once per volume. This requires specifying different return values for the describeVolumesStub per region, since the AWS describeVolumes function should only return volumes which belong to a single region.

We'd like your input on the last test, in particular. It's not very pretty, because in order to specify separate return values per region, it's necessary to specify the exact input to describeVolumesStub. To reduce duplication of the parameters to the 'describeVolumes' AWS function-- and because these parameters are unchanging--we created a new field in HouseKeeper to store these parameters. I'm not sure if it's ideal to store these as a global variable, but it definitely makes the testing easier.

One more thought related to the last test: would it make sense to remove the "method" parameter from the describe[...]Stub functions, since we already have an if-else block that checks what method is being requested and returns the appropriate stub? It seems a bit redundant, and the presence of that parameter means that we need to include the parameter when specifying the desired output of the stub.

@djmitche @imbstack @jhford: @SamanthaYu  and I would really appreciate any thoughts or feedback you have. Thanks for all the help so far!

