### PR TITLE
Drop the SQL tables after each suite that uses it.

### DIFF
--- a/test/api_test.js
+++ b/test/api_test.js
@@ -49,8 +49,9 @@ describe('Api', () => {
     server = await main('server', {profile: 'test', process: 'test', runaws});
   });
 
-  after(() => {
+  after(async () => {
     testing.fakeauth.stop();
+    await state._runScript('drop-db.sql');
   });
 
   afterEach(() => {

--- a/test/cloud-watch-event-listener_test.js
+++ b/test/cloud-watch-event-listener_test.js
@@ -59,6 +59,10 @@ describe('Cloud Watch Event Listener', () => {
     listener = new CloudWatchEventListener({state, sqs, ec2, region, monitor, keyPrefix: cfg.app.keyPrefix, tagger});
   });
 
+  after(async() => {
+    await state._runScript('drop-db.sql');
+  });
+
   // I could add these helper functions to the actual state.js class but I'd
   // rather not have that be so easy to call by mistake in real code
   beforeEach(async() => {

--- a/test/housekeeping_test.js
+++ b/test/housekeeping_test.js
@@ -74,6 +74,10 @@ describe('House Keeper', () => {
     });
   });
 
+  after(async() => {
+    await state._runScript('drop-db.sql');
+  });
+
   afterEach(() => {
     sandbox.restore();
   });

--- a/test/spot-request-poll_test.js
+++ b/test/spot-request-poll_test.js
@@ -11,6 +11,8 @@ describe('Spot Request Poller', () => {
   before(async() => {
     // We want a clean DB state to verify things happen as we intend
     state = await main('state', {profile: 'test', process: 'test'});
+    await state._runScript('drop-db.sql');
+    await state._runScript('create-db.sql');
   });
 
   beforeEach(async() => {
@@ -26,6 +28,10 @@ describe('Spot Request Poller', () => {
       status: 'pending-fulfillment',
       created: new Date(),
     };
+  });
+
+  after(async() => {
+    await state._runScript('drop-db.sql');
   });
 
   afterEach(() => {

--- a/test/state_test.js
+++ b/test/state_test.js
@@ -13,6 +13,10 @@ describe('State', () => {
     await db._runScript('create-db.sql');
   });
 
+  after(async() => {
+    await db._runScript('drop-db.sql');
+  });
+
   // I could add these helper functions to the actual state.js class but I'd
   // rather not have that be so easy to call by mistake in real code
   beforeEach(async() => {


### PR DESCRIPTION
Thanks auni53 for highlighting this issue.  There's a bit of a problem
here where the order of test files will have a profound effect on
whether or not the tests pass or not.  Each test file should delete
existing tables, create them and then delete them when they're done.  If
there was a way to do a before()/after() that spans all the tests, this
would be a great place to run a database drop and create.