### PR TITLE
Add call of reportAmiUsage to the /spot-request method when requesting spot instance and update tests

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -163,6 +163,15 @@ api.declare({
     } catch (err) {
       log.warn({err}, 'Error while tagging, ignoring');
     }
+    
+    try {
+      await this.state.reportAmiUsage({
+        region: Region,
+        id: imageId,
+      });
+    } catch (err) {
+      log.warn({err}, 'Error while reporting AMI usage, ignoring');
+    }
 
     try {
       await this.state.insertSpotRequest(opts); 

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -197,6 +197,10 @@ describe('Api', () => {
       assume(runaws.callCount).equals(2);
       assume(runaws.args[0][1]).equals('requestSpotInstances');
       assume(runaws.args[1][1]).equals('createTags');
+      let amiUsage = await state.listAmiUsage();
+      assume(amiUsage).has.length(1);
+      assume(amiUsage[0]).has.property('region', region);
+      assume(amiUsage[0]).has.property('id', imageId);
       let call = runaws.firstCall.args;
       assume(call[0].config.region).equals(region);
       assume(call[1]).equals('requestSpotInstances');
@@ -220,6 +224,10 @@ describe('Api', () => {
       assume(runaws.callCount).equals(2);
       assume(runaws.args[0][1]).equals('requestSpotInstances');
       assume(runaws.args[1][1]).equals('createTags');
+      amiUsage = await state.listAmiUsage();
+      assume(amiUsage).has.length(1);
+      assume(amiUsage[0]).has.property('region', region);
+      assume(amiUsage[0]).has.property('id', imageId);
     });
   });
 


### PR DESCRIPTION
Added a call for reportAmiUsage similar to how insertSpotRequest and tagResources are called within that method. From what I understand, that's all I have to do here. I also updated the test to check that AMI usage has been reported.
@jhford @walac 