### PR TITLE
Add endpoint for /internal/amiusage

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -577,6 +577,22 @@ api.declare({
 });
 
 /**
+ * List AMIs and their usage
+ */
+api.declare({
+  method: 'get',
+  route: '/internal/ami-usage',
+  name: 'amiUsage',
+  title: 'See the list of AMIs and their usage',
+  stability: API.stability.experimental,
+  scopes: [['ec2-manager:internals']],
+  description: 'Lists out all of the AMIs and their usage',
+}, async function(req, res) {
+  let amiUsage = await this.state.listAmiUsage();
+  return res.reply(amiUsage);
+});
+
+/**
  * Show stats on the Database Pool
  */
 api.declare({

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -424,5 +424,16 @@ describe('Api', () => {
       assume(usw2.values).has.lengthOf(1);
       assume(usw2.values[0]).equals('r-1234');
     });
+  
+    it('should list AMI usage', async() => {
+      await state.reportAmiUsage({
+        region: region,
+        id: imageId,
+      });
+      let result = await client.amiUsage();
+      assume(result).has.lengthOf(1);
+      assume(result[0]).has.property('region', region);
+      assume(result[0]).has.property('id', imageId);
+    });
   });
 });


### PR DESCRIPTION
Implemented an endpoint “GET /internal/ami-usage” which lists out all of the AMIs and their usage and included unit test