### PR TITLE
Switch terminateInstance to a post method

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -404,7 +404,7 @@ api.declare({
  * Terminate a single instance
  */
 api.declare({
-  method: 'delete',
+  method: 'post',
   route: '/region/:region/instance/:instanceId',
   name: 'terminateInstance',
   title: 'Terminate an instance',


### PR DESCRIPTION
Per our agreement in [RFC#97](https://github.com/taskcluster/taskcluster-rfcs/issues/97), actions will be sent using a POST request.