### PR TITLE
Allow deletion of worker type resources with a worker-type scope

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -409,7 +409,10 @@ api.declare({
   name: 'terminateInstance',
   title: 'Terminate an instance',
   stability: API.stability.experimental,
-  scopes: [['ec2-manager:manage-instances:<region>:<instanceId>']],
+  scopes: [
+    ['ec2-manager:manage-instances:<region>:<instanceId>'],
+    ['ec2-manager:manage-resources:<workerType>'],
+  ],
   description: [
     'Terminate an instance in a specified region',
   ].join(' '),
@@ -417,7 +420,30 @@ api.declare({
   let region = req.params.region;
   let instanceId = req.params.instanceId;
 
-  if (!req.satisfies({region, instanceId})) { return undefined; }
+  // We need to look up the worker type in the database, but since that's more
+  // work that just using route parameters, we should first try the relatively
+  // lower cost check for just the region/instanceId scope (which in practise
+  // would be an ec2-manager[:manage-instances]:* scope) first.  If this fails,
+  // we'll look up the instanceId and region in the database to see if we can
+  // determine its worker type and use that for auth.  If we find no instances
+  // in the database, we're just going to return undefined because this
+  // instance is not managed, and should not be authorized.  If there's more
+  // than one, the database is not providing the relational guarantees it
+  // should
+  if (!req.satisfies({region, instanceId})) { 
+    let workerTypes = await this.state.listInstances({id: instanceId, region});
+    switch (workerTypes.len != 1) {
+      case 0:
+        return undefined;
+      case 1:
+        if (!req.satisfies({region, instanceId, workerType: workerTypes[0]})) {
+          return undefined;
+        }
+        break;
+      default:
+        throw new Error('Database schema guarantees aren\'t being enforced');
+    }
+  }
 
   if (!this.regions.includes(region)) {
     res.reportError('ResourceNotFound', 'Region is not configured', {});
@@ -456,7 +482,10 @@ api.declare({
   name: 'cancelSpotInstanceRequest',
   title: 'Cancel a request for a spot instance',
   stability: API.stability.experimental,
-  scopes: [['ec2-manager:manage-spot-requests:<region>:<requestId>']],
+  scopes: [
+    ['ec2-manager:manage-spot-requests:<region>:<requestId>'],
+    ['ec2-manager:manage-resources:<workerType>'],
+  ],
   description: [
     'Cancel a spot instance request in a region',
   ].join(' '),
@@ -464,8 +493,31 @@ api.declare({
   let region = req.params.region;
   let requestId = req.params.requestId;
 
-  if (!req.satisfies({region, requestId})) { return undefined; }
-
+  // We need to look up the worker type in the database, but since that's more
+  // work that just using route parameters, we should first try the relatively
+  // lower cost check for just the region/requestId scope (which in practise
+  // would be an ec2-manager[:manage-spot-requests]:* scope) first.  If this
+  // fails, we'll look up the requestId and region in the database to see if we
+  // can determine its worker type and use that for auth.  If we find no
+  // spot-requests in the database, we're just going to return undefined
+  // because this spot-request is not managed, and should not be authorized.
+  // If there's more than one, the database is not providing the relational
+  // guarantees it should
+  if (!req.satisfies({region, requestId})) { 
+    let workerTypes = await this.state.listSpotRequests({id: requestId, region});
+    switch (workerTypes.len != 1) {
+      case 0:
+        return undefined;
+      case 1:
+        if (!req.satisfies({region, requestId, workerType: workerTypes[0]})) {
+          return undefined;
+        }
+        break;
+      default:
+        throw new Error('Database schema guarantees aren\'t being enforced');
+    }
+  }
+  
   if (!this.regions.includes(region)) {
     res.reportError('ResourceNotFound', 'Region is not configured', {});
   }


### PR DESCRIPTION
Instead of forcing a specific instanceId/requestId/region scope, let's
say that if the desired instance/request is managed by this process and
has a worker type for which the appropriate scope has been granted, you
can kill/cancel the instance/request