### PR TITLE
Fixed EBS volume API documentation

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -675,8 +675,8 @@ api.declare({
  *  region: string,
  *  volumetype: string,
  *  state: string,
- *  totalcount: string,
- *  totalgb: string,
+ *  totalcount: integer,
+ *  totalgb: integer,
  *  touched: timestamp,
  * }
  */
@@ -698,8 +698,8 @@ api.declare({
         'region: string,',
         'volumetype: string,',
         'state: string,',
-        'totalcount: string,',
-        'totalgb: string,',
+        'totalcount: integer,',
+        'totalgb: integer,',
         'touched: timestamp (last time that information was updated),',
       ].join('\n\t'),
       '}',


### PR DESCRIPTION
We forgot to update the API documentation so that it says that `totalgb` and `totalcount` are integers instead of strings.