### PR TITLE
Bug 1428068: Handle EC2 prices endpoint pagination

### DIFF
--- a/lib/pricing-poller.js
+++ b/lib/pricing-poller.js
@@ -135,44 +135,57 @@ class PricingPoller {
 
     for (let region of this.regions) {
       let ec2 = this.ec2[region];
-      let [azResult, priceResult] = await Promise.all([
-        this.runaws(ec2, 'describeAvailabilityZones', {
-          Filters: [{
-            Name: 'state',
-            Values: ['available'],
-          }],
-        }),
-        this.runaws(ec2, 'describeSpotPriceHistory', {
+      let nextToken = undefined;
+      let azResult = await this.runaws(ec2, 'describeAvailabilityZones', {
+        Filters: [{
+          Name: 'state',
+          Values: ['available'],
+        }],
+      });
+      let zones = azResult.AvailabilityZones.map(x => x.ZoneName);
+
+      do {
+        const requestParams = {
           StartTime: startTime,
           Filters: [{
             Name: 'product-description',
             Values: ['Linux/UNIX'],
           }],
-        }),
-      ]);
+        };
+        if (nextToken) {
+          requestParams.NextToken = nextToken;
+        }
 
-      // Get the information from the API responses that we care about
-      let zones = azResult.AvailabilityZones.map(x => x.ZoneName);
-      let pricePoints = priceResult.SpotPriceHistory.filter(x => zones.includes(x.AvailabilityZone));
+        let priceResult = await this.runaws(
+          ec2,
+          'describeSpotPriceHistory',
+          requestParams
+        );
 
-      // Determine what the prices which the API described.
-      let spotPrices = this._findSpotPricesForRegion({pricePoints});
-      let onDemandPrices = this._findOnDemandPricesForRegion();
+        nextToken = priceResult.NextToken;
 
-      // Add some information to the spot prices
-      spotPrices = spotPrices.map(x => {
-        Object.assign(x, {type: 'spot', region});
-        return x;
-      });
+        // Get the information from the API responses that we care about
+        let pricePoints = priceResult.SpotPriceHistory.filter(x => zones.includes(x.AvailabilityZone));
 
-      // Add some information to the on-demand prices
-      onDemandPrices = onDemandPrices.map(x => {
-        Object.assign(x, {type: 'ondemand', region});
-        return x;
-      });
+        // Determine what the prices which the API described.
+        let spotPrices = this._findSpotPricesForRegion({pricePoints});
+        let onDemandPrices = this._findOnDemandPricesForRegion();
 
-      Array.prototype.push.apply(prices, spotPrices);
-      Array.prototype.push.apply(prices, onDemandPrices);
+        // Add some information to the spot prices
+        spotPrices = spotPrices.map(x => {
+          Object.assign(x, {type: 'spot', region});
+          return x;
+        });
+
+        // Add some information to the on-demand prices
+        onDemandPrices = onDemandPrices.map(x => {
+          Object.assign(x, {type: 'ondemand', region});
+          return x;
+        });
+
+        Array.prototype.push.apply(prices, spotPrices);
+        Array.prototype.push.apply(prices, onDemandPrices);
+      } while (nextToken);
     }
 
     prices.sort((a, b) => {

--- a/test/pricing-poller_test.js
+++ b/test/pricing-poller_test.js
@@ -97,6 +97,7 @@ describe('Pricing', () => {
     });
 
     describeSPHStub.onFirstCall().returns({
+      NextToken: 'abc123',
       SpotPriceHistory: [{
         Timestamp: '2017-07-05T13:11:21.000Z', 
         AvailabilityZone: zones[0], 
@@ -130,7 +131,42 @@ describe('Pricing', () => {
       }],
     });
 
-    //describeSPHStub.onSecondCall().throws();
+    describeSPHStub.onSecondCall().callsFake((ec2, method, params) => {
+      assume(params.NextToken).is.equal('abc123');
+      return {
+        SpotPriceHistory: [{
+          Timestamp: '2017-08-05T13:11:21.000Z',
+          AvailabilityZone: 'd',
+          InstanceType: 'm3.medium',
+          ProductDescription: 'Linux/UNIX',
+          SpotPrice: '1.1',
+        }, {
+          Timestamp: '2017-08-05T13:14:21.000Z',
+          AvailabilityZone: 'd',
+          InstanceType: 'm3.medium',
+          ProductDescription: 'Linux/UNIX',
+          SpotPrice: '1.2',
+        }, {
+          Timestamp: '2017-08-05T13:14:21.000Z',
+          AvailabilityZone: 'd',
+          InstanceType: 'm3.xlarge',
+          ProductDescription: 'Linux/UNIX',
+          SpotPrice: '1.7',
+        }, {
+          Timestamp: '2017-08-05T13:14:21.000Z',
+          AvailabilityZone: 'd',
+          InstanceType: 'm3.xlarge',
+          ProductDescription: 'Linux/UNIX',
+          SpotPrice: '1.1',
+        }, {
+          Timestamp: '2017-08-05T13:14:21.000Z',
+          AvailabilityZone: zones[2],
+          InstanceType: 'm3.medium',
+          ProductDescription: 'Linux/UNIX',
+          SpotPrice: '1.2',
+        }],
+      };
+    });
 
     describeAZStub.onFirstCall().returns({
       AvailabilityZones: [{
@@ -156,11 +192,14 @@ describe('Pricing', () => {
     await poller.poll();
 
     let expected = [
-      {instanceType: 'm3.medium', price: 0.1, region, type: 'spot', zone: zones[1]}, 
-      {instanceType: 'm3.medium', price: 0.2, region, type: 'spot', zone: zones[0]}, 
-      {instanceType: 'm3.xlarge', price: 0.7, region, type: 'spot', zone: zones[0]}, 
+      {instanceType: 'm3.medium', price: 0.1, region, type: 'spot', zone: zones[1]},
+      {instanceType: 'm3.medium', price: 0.2, region, type: 'spot', zone: zones[0]},
+      {instanceType: 'm3.xlarge', price: 0.7, region, type: 'spot', zone: zones[0]},
+      {instanceType: 'm3.medium', price: 1.2, region, type: 'spot', zone: zones[2]},
     ];
 
+    assume(describeSPHStub.callCount).is.equal(2);
+    assume(describeAZStub.callCount).is.equal(1);
     assume(poller.prices).deeply.equals(expected);
   });
 


### PR DESCRIPTION
The DescribeSpotPriceHistory endpoint returns a field call NextToken
that, if not null, indicates there are additional data to fetch.

On next call, NextToken should be an input parameters to tell the server
we are fetching the remaining data.

Notice it had to move DescribeAvailabilityZones out of the loop because
it doesn't do pagination.