### PR TITLE
Improve how we call AWS endpoints

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -30,7 +30,7 @@ defaults:
     sslEnabled: true
     httpOptions:
       timeout: 10000
-      connect: 2000
+      connectTimeout: 2000
   postgres:
     databaseUrl: !env DATABASE_URL
   server:
@@ -60,7 +60,7 @@ production:
     env: production
     forceSSL: true
     trustProxy: true
-    baseUrl: 'https://ec2-manager.herokuapp.com/v1'
+    baseUrl: 'https://ec2-manager.taskcluster.net/v1'
   app:
     id: 'ec2-manager-production'
     publishMetadata: true
@@ -75,7 +75,7 @@ staging:
     env: production
     forceSSL: true
     trustProxy: true
-    baseUrl: 'https://ec2-manager-staging.herokuapp.com/v1'
+    baseUrl: 'https://ec2-manager-staging.taskcluster.net/v1'
   app:
     id: 'ec2-manager-staging'
     publishMetadata: false

--- a/config.yml
+++ b/config.yml
@@ -26,7 +26,11 @@ defaults:
   aws:
     accessKeyId: !env AWS_ACCESS_KEY_ID
     secretAccessKey: !env AWS_SECRET_ACCESS_KEY
-    maxRetries: 10
+    maxRetries: 3
+    sslEnabled: true
+    httpOptions:
+      timeout: 10000
+      connect: 2000
   postgres:
     databaseUrl: !env DATABASE_URL
   server:

--- a/lib/api.js
+++ b/lib/api.js
@@ -164,31 +164,10 @@ api.declare({
       log.warn({err}, 'Error while reporting AMI usage, ignoring');
     }
 
-    try {
-      await this.state.insertInstance(opts); 
+    await this.state.upsertInstance(opts); 
 
-      log.debug(opts, 'finished inserting instance into database'); 
-      res.status(204).end();
-    } catch (err) {
-      // https://www.postgresql.org/docs/9.6/static/errcodes-appendix.html
-      if (err.code === '23505') {
-        // So when there's a conflict we're going to do nothing.  You might be
-        // concerned, but alas, fear not intrepid hacker!  We know that the
-        // primary key (region, id) already exists so that means we've already
-        // inserted *something* into the database.  Now, you'd be totally right
-        // when you question what happens if a second request was made with
-        // different values.  Fear not, we wouldn't get here if the same
-        // request was made but with values which would alter the values
-        // inserted into the database because EC2 enforces idempotency through
-        // our use of the ClientToken option.  I guess we're trusting the
-        // idempotency of EC2.  When we're trusting it with so many other
-        // things, I don't see this being a problem.
-        return res.status(204).end();
-      } else {
-        console.dir(err.stack || err);
-        throw err;
-      }
-    }
+    log.debug(opts, 'finished inserting instance into database'); 
+    res.status(204).end();
   } catch (err) {
     log.error({err}, 'runInstance');
     throw err;

--- a/lib/api.js
+++ b/lib/api.js
@@ -607,7 +607,7 @@ api.declare({
   name: 'dbpoolStats',
   title: 'Statistics on the Database client pool',
   stability: API.stability.experimental,
-  //scopes: [['ec2-manager:internals']],
+  scopes: [['ec2-manager:internals']],
   description: 'This method is only for debugging the ec2-manager',
 }, async function(req, res) {
   let pool = this.state._pgpool;

--- a/lib/api.js
+++ b/lib/api.js
@@ -607,15 +607,15 @@ api.declare({
   name: 'dbpoolStats',
   title: 'Statistics on the Database client pool',
   stability: API.stability.experimental,
-  scopes: [['ec2-manager:internals']],
+  //scopes: [['ec2-manager:internals']],
   description: 'This method is only for debugging the ec2-manager',
 }, async function(req, res) {
-  let pool = this.state._pgpool.pool;
+  let pool = this.state._pgpool;
   let result = {
-    inuse: pool._inUseObjects.length || 0,
-    avail: pool._availableObjects.length || 0,
-    waiting: pool._waitingClients.length || 0,
-    count: pool._count || 0,
+    max: pool.options.max,
+    idle: pool.idleCount,
+    total: pool.totalCount,
+    waiting: pool.waitingCount,
   };
   return res.reply(result);
 });

--- a/lib/api.js
+++ b/lib/api.js
@@ -27,6 +27,7 @@ let api = new API({
     'runaws',
     'pricing',
     'tagger',
+    'monitor',
   ],
 });
 
@@ -115,15 +116,40 @@ api.declare({
       {ResourceType: 'volume', Tags: tags},
     ];
 
+    // We want to track how long an instance lived for
+    let groupings = [
+      'overall',
+      'instance-type.' + LaunchInfo.InstanceType,
+      'worker-type.' + workerType,
+      'region.' + Region,
+    ];
+
     let result;
     try {
       result = await this.runaws(this.ec2[Region], 'runInstances', LaunchInfo);
       // TODO: Put a couple more useful fields here, maybe instance type and price.
       // This should be simple, just reaching into the launch spec.
       log.info({region: Region}, 'Requested instance');
+      for (grouping of groupings.map(x => `create-instance.normal.${x}.${RequestType}`)) {
+        this.monitor.count(grouping);
+      }
     } catch (err) {
       // https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html
       log.error({err, LaunchInfo}, 'Error requesting an instance');
+      for (grouping of groupings.map(x => `create-instance.exceptional.${x}.${RequestType}`)) {
+        this.monitor.count(grouping);
+      }
+      let errMsg = [
+        `THIS IS A WORKER TYPE CONFIGURATION ISSUE OF ${workerType} OR `,
+        `AN EC2 SERVICE DISRUPTION IN ${region}/${instanceType}!!!  `,
+        'This report is part of the normal operation of EC2-Manager ',
+        `and is not a bug: ${err.code}: ${err.message}`,
+      ];
+      this.monitor.reportError(new Error(errMsg.join('')), 'info', {
+        workerType,
+        instanceType: LaunchInfo.InstanceType,
+        region: Region,
+      });
       switch (err.code) {
         case 'InvalidParameter':
         case 'InvalidParameterCombination':

--- a/lib/aws-request.js
+++ b/lib/aws-request.js
@@ -55,7 +55,7 @@ async function runAWSRequest(service, method, body, state) {
     }
   }
 
-  return new Promise(async (resolve, reject) => {
+  return new Promise(async(resolve, reject) => {
 
     // We need to make sure that this promise, if awaited on a second
     // time will resolve or reject exactly the same way, per the promise spec
@@ -102,7 +102,7 @@ async function runAWSRequest(service, method, body, state) {
     });
 
     // Handle failure
-    request.on('error', async (error, response) => {
+    request.on('error', async(error, response) => {
       try {
         clearTimeout(timeout);
         requestInfo.duration = duration(start);

--- a/lib/aws-request.js
+++ b/lib/aws-request.js
@@ -3,6 +3,7 @@ const delayer = require('./delayer');
 const log = require('./log');
 
 const NS_PER_SEC = 1e9;
+const MAX_REQUEST_DURATION = 10 * 1000; // 25s
 
 // Return duration in us based on a start
 function duration(start) {
@@ -11,26 +12,9 @@ function duration(start) {
 }
 
 /**
- * This method will run an EC2 operation.  Because the AWS-SDK client is so
- * much fun to work with, we need to do the following things above what it does
- * to get useful information out of it.
- *
- *   1. We want to have exceptions that always have region, method and service
- *      name if available
- *   2. Any requests which would have a requestId should include it in their
- *      exceptions
- *   3. Sometimes promises from AWS-SDK just magically never return and never
- *      timeout even though we've set those options.  We have our own timeout
- *   4. Useful logging that includes useful debugging information
- *   5. Because we're catching the exceptions here, there's a *chance* that
- *      we might get useful stack traces.  AWS-SDK exceptions which aren't
- *      caught seem to have the most utterly useless stacks, which only
- *      have frames in their own state machine and never include the call
- *      site
- *
- * I am halfway tempted to rewrite this file using aws4 because it is a more
- * sensible library.
- *
+ * This method will run an EC2 operation as a promise.  This promise has a
+ * built-in timeout feature, which ensures that even when the AWS-SDK library
+ * timeout itself doesn't work, requests complete in finite time.
  */
 async function runAWSRequest(service, method, body, state) {
   assert(typeof service === 'object');
@@ -52,7 +36,6 @@ async function runAWSRequest(service, method, body, state) {
   // Special service.method's which should get extra metadata
   if (requestInfo.service === 'ec2') {
     if (method === 'runInstances' && body) {
-      
       if (body.TagSpecifications) {
         loop1:
         for (let spec of body.TagSpecifications || []) {
@@ -64,7 +47,6 @@ async function runAWSRequest(service, method, body, state) {
           }
         }
       }
-
       if (body.Placement && body.Placement.AvailabilityZone) {
         requestInfo.az = body.Placement.AvailabilityZone;
       }
@@ -73,79 +55,92 @@ async function runAWSRequest(service, method, body, state) {
     }
   }
 
-  let request;
+  return new Promise(async (resolve, reject) => {
 
-  let start = process.hrtime();
+    // We need to make sure that this promise, if awaited on a second
+    // time will resolve or reject exactly the same way, per the promise spec
+    let rejectionValue;
+    let resolutionValue;
+    if (rejectionValue) {
+      return reject(rejectionValue);
+    }
+    if (resolutionValue) {
+      return resolve(resolutionValue);
+    }
 
-  try {
-    request = service[method](body);
+    // Prepare the request
+    let request = service[method](body);
+    let start;
 
-    let response = await Promise.race([
-      request.promise(),
-      delayer(240 * 1000)().then(() => {
-        let err = new Error(`Timeout in ${region} ${serviceId}.${method}`);
-        err.region = region;
-        err.service = serviceId;
-        err.body = body;
+    // We want to have requests take no longer than this number of
+    // milliseconds.  We've found that any timeouts built into the aws-sdk
+    // client are unreliable
+    let timeout = setTimeout(() => request.abort(), MAX_REQUEST_DURATION);
 
-        requestInfo.error = true;
-        requestInfo.code = 'TC.Timeout';
-        requestInfo.messsage = 'Custom Taskcluster derived timeout -- client froze!';
+    // Handle success
+    request.on('success', async response => {
+      try {
+        clearTimeout(timeout);
         requestInfo.duration = duration(start);
 
-        throw err;
-      }),
-    ]);
+        requestInfo.requestId = response.requestId;
+        if (!requestInfo.requestId) {
+          // Probably paranoia, but better to know and not needed it than the
+          // alternative.  We don't want to kill the service though
+          let msg = `${requestInfo.service}:${requestInfo.region}.${requestInfo.method} missing requestId`;
+          log.warn(new Error(msg), 'missing requestId on succesful request');
+          requestInfo.requestId = '----- MISSING REQUEST ID -----';
+        }
 
-    requestInfo.duration = duration(start);
-
-    if (request.response.requestId) {
-      requestInfo.requestId = request.response.requestId;
-    }
-
-    requestInfo.error = false;
-
-    log.debug(requestInfo, 'aws request success');
-
-    return response;
-  } catch (err) {
-    // We want to have properties we think might be in the error and
-    // are relevant right here
-    requestInfo.error = true;
-    requestInfo.code = err.code;
-    requestInfo.message = err.message;
-
-    if (!requestInfo.duration) {
-      requestInfo.duration = duration(start);
-    }
-
-    if (!requestInfo.requestId) {
-      if (request && request.response && request.response.error) {
-        requestInfo.requestId = request.response.error.requestId;
-      } else if (request && request.response) {
-        requestInfo.requestId = request.response.requestId;
+        requestInfo.error = false;
+        log.debug(requestInfo, 'aws request successful');
+        await state.logAWSRequest(requestInfo);
+        return resolve(resolutionValue = response.data);
+      } catch (err) {
+        return reject(rejectionValue = err);
       }
-    }
+    });
 
-    let newErr = new Error('Failure to run AWS Request');
-    Object.assign(newErr, requestInfo);
-    newErr.originalErr = err;
+    // Handle failure
+    request.on('error', async (error, response) => {
+      try {
+        clearTimeout(timeout);
+        requestInfo.duration = duration(start);
+        
+        requestInfo.error = true;
+        requestInfo.code = error.code;
+        requestInfo.message = error.message;
 
-    let logObj = Object.assign({}, requestInfo, {body});
+        // Try *really* hard to get the requestId
+        requestInfo.requestId = error.requestId || response.requestId || request.response.requestId;
 
-    if (logObj.message.length > 253) {
-      logObj.message = logObj.message.slice(0, 253) + '...';
-    }
-    log.error(requestInfo, 'aws request failure');
+        // If we abort the request before we get a requestId, we should still do something to avoid
+        // this service from being killed
+        if (!requestInfo.requestId && error.code === 'RequestAbortedError') {
+          requestInfo.requestId = '----- ABORTED REQUEST -----';
+        }
+        
+        if (!requestInfo.requestId) {
+          let msg = `${requestInfo.service}:${requestInfo.region}.${requestInfo.method} missing requestId`;
+          log.error(new Error(msg), 'missing requestId on failed request');
+          requestInfo.requestId = '----- MISSING REQUEST ID -----';
+        }
 
-    throw newErr;
-  } finally {
+        await state.logAWSRequest(requestInfo);
+
+        return reject(rejectionValue = error);
+      } catch (err) {
+        return reject(rejectionValue = err);
+      }
+    });
+
     try {
-      await state.logAWSRequest(requestInfo);
-    } catch (err2) {
-      log.error({err: err2}, 'error reporting aws request');
+      start = process.hrtime();
+      request.send();
+    } catch (err) {
+      return reject(rejectionValue = err);
     }
-  }
+  });
 }
 
 module.exports = {runAWSRequest};

--- a/lib/cloud-watch-event-listener.js
+++ b/lib/cloud-watch-event-listener.js
@@ -128,6 +128,18 @@ class CloudWatchEventListener extends events.EventEmitter {
         workerType: instance.workerType,
         az: instance.az,
       }, 'tracked instance termination');
+
+      // We want to track how long an instance lived for
+      let lifespan = generated - instance.launched;
+      let groupings = [
+        'overall',
+        'instance-type.' + instance.instanceType,
+        'worker-type.' + instance.workerType,
+        'region.' + instance.region,
+      ].map(x => 'instance-lifespan.' + x);
+      for (let grouping of groupings) {
+        this.monitor.measure(grouping, lifespan);
+      }
     } else {
       let wasUpdated = await this.state.updateInstanceState({
         region,

--- a/lib/cloud-watch-event-listener.js
+++ b/lib/cloud-watch-event-listener.js
@@ -106,6 +106,7 @@ class CloudWatchEventListener extends events.EventEmitter {
       let instances = await this.state.listInstances({region, id}, transaction);
       if (instances.length === 0) {
         hlog.debug('untracked instance termination');
+        await this.state.commitTransaction(transaction);
         return;
       }
       let instance = instances[0];

--- a/lib/cloud-watch-event-listener.js
+++ b/lib/cloud-watch-event-listener.js
@@ -92,12 +92,7 @@ class CloudWatchEventListener extends events.EventEmitter {
 
     let dbResponse;
 
-    try {
-      dbResponse = await this.state.listInstances({region, id}, transaction);
-    } catch (err) {
-      await this.state.rollbackTransaction(transaction);
-      throw err;
-    }
+    dbResponse = await this.state.listInstances({region, id}, transaction);
 
     if (dbResponse.length > 1) {
       // for this case to be hit, there'd have to be a database schema problem
@@ -147,39 +142,33 @@ class CloudWatchEventListener extends events.EventEmitter {
       } 
 
       if (dbResponse.lastEvent && dbResponse.lastEvent < generated) {
-        try {
-          // We only want to handle the terminated case specially, since in
-          // other cases we'll filter for only pending and running as query
-          // options when talking to the db
-          if (state === 'terminated') {
-            await this.state.upsertTermination({
-              id: dbResponse.id,
-              workerType: dbResponse.workerType,
-              region: dbResponse.region,
-              az: dbResponse.az,
-              instanceType: dbResponse.instanceType,
-              imageId: dbResponse.imageId,
-              launched: dbResponse.launched,
-              terminated: generated,
-              lastEvent: generated,
-            }, transaction);
-            await this.state.removeInstance({region, id}, transaction);
-            log.debug(logInfo, 'CloudWatch Event resulting in deletion');
-          } else {
-            await this.state.updateInstanceState({
-              region,
-              id,
-              state,
-              lastEvent: generated,
-            }, transaction);
-            log.info(logInfo, 'CloudWatch Event resulting in state update');
-          }
-          await this.state.commitTransaction(transaction);
-        } catch (err) {
-          await this.state.rollbackTransaction(transaction);
-          log.error(err, 'trying to update or remove instance');
-          throw err;
+        // We only want to handle the terminated case specially, since in
+        // other cases we'll filter for only pending and running as query
+        // options when talking to the db
+        if (state === 'terminated') {
+          await this.state.upsertTermination({
+            id: dbResponse.id,
+            workerType: dbResponse.workerType,
+            region: dbResponse.region,
+            az: dbResponse.az,
+            instanceType: dbResponse.instanceType,
+            imageId: dbResponse.imageId,
+            launched: dbResponse.launched,
+            terminated: generated,
+            lastEvent: generated,
+          }, transaction);
+          await this.state.removeInstance({region, id}, transaction);
+          log.debug(logInfo, 'CloudWatch Event resulting in deletion');
+        } else {
+          await this.state.updateInstanceState({
+            region,
+            id,
+            state,
+            lastEvent: generated,
+          }, transaction);
+          log.info(logInfo, 'CloudWatch Event resulting in state update');
         }
+        await this.state.commitTransaction(transaction);
       } else {
         // While we didn't write anything, we did lock the row and claim a
         // client.  We should release those

--- a/lib/cloud-watch-event-listener.js
+++ b/lib/cloud-watch-event-listener.js
@@ -88,108 +88,57 @@ class CloudWatchEventListener extends events.EventEmitter {
     // received it
     let generated = new Date(body.time);
 
-    let transaction = await this.state.beginTransaction();
+    let hlog = log.child({region, id, state});
 
-    let dbResponse;
+    // Let's log this event.  We're doing this outside of any transaction because we need to
+    // log it regardless of the outcome
+    try {
+      await this.state.logCloudWatchEvent({region, id, state, generated});
+    } catch (err) {
+      // We don't want to block things, but let's bubble up the error for the
+      // time being
+      this.monitor.reportError(err);
+      hlog.warn(err, 'failure while reporting cloudwatch event to database');
+    }
 
-    dbResponse = await this.state.listInstances({region, id}, transaction);
-
-    if (dbResponse.length > 1) {
-      // for this case to be hit, there'd have to be a database schema problem
-      await this.state.commitTransaction(transaction);
-      throw new Error('verify database integrity!');
-    } else if (dbResponse.length < 1) {
-      await this.state.commitTransaction(transaction);
-      log.debug({id, region, state}, 'skipping messages for untracked instances');
-    } else {
-      // Now that we're only monitoring instances which are in the state
-      // database, we no longer want to log cloudwatch events for unrelated
-      // instances.  We do not do this as part of the ongoing transaction
-      // because we want this logged regardless of whether that transaction
-      // results in a commit or rollback
-      try {
-        await this.state.logCloudWatchEvent({region, id, state, generated});
-      } catch (err) {
-        // We don't want to block things, but let's bubble up the error for the
-        // time being
-        this.monitor.reportError(err);
+    if (state === 'terminated') {
+      let transaction = await this.state.beginTransaction();
+      let instances = await this.state.listInstances({region, id}, transaction);
+      if (instances.length === 0) {
+        hlog.debug('untracked instance termination');
+        return;
       }
-      
-      dbResponse = dbResponse[0];
-      // If there's a response from the database, we know that we already have
-      // this information in the database.  We'll use this information to
-      // figure out the immutable metadata
+      let instance = instances[0];
 
-      let logInfo = {
-        workerType: dbResponse.workerType,
-        region: dbResponse.region,
-        az: dbResponse.az,
-        id: id,
-        instanceType: dbResponse.instanceType,
-        imageId: dbResponse.imageId,
-        launched: dbResponse.launched,
+      await this.state.upsertTermination({
+        id: instance.id,
+        workerType: instance.workerType,
+        region: instance.region,
+        az: instance.az,
+        instanceType: instance.instanceType,
+        imageId: instance.imageId,
+        launched: instance.launched,
+        terminated: generated,
+        lastEvent: generated,
+      }, transaction);
+      await this.state.removeInstance({region, id}, transaction);
+      await this.state.commitTransaction(transaction);
+      hlog.debug({
+        workerType: instance.workerType,
+        az: instance.az,
+      }, 'tracked instance termination');
+    } else {
+      let wasUpdated = await this.state.updateInstanceState({
+        region,
+        id,
         state,
         lastEvent: generated,
-        metadataSource: 'db',
-      };
-      
-      // Note that since we're now inserting instances directly into the
-      // database now, we're always going to have a pending state in the db for
-      // managed instances.  This means that most 'pending' state messages will
-      // be ignored.
-      if (dbResponse.lastEvent && dbResponse.lastEvent === generated) {
-        log.warn('whoa!');
-      } 
-
-      if (dbResponse.lastEvent && dbResponse.lastEvent < generated) {
-        // We only want to handle the terminated case specially, since in
-        // other cases we'll filter for only pending and running as query
-        // options when talking to the db
-        if (state === 'terminated') {
-          await this.state.upsertTermination({
-            id: dbResponse.id,
-            workerType: dbResponse.workerType,
-            region: dbResponse.region,
-            az: dbResponse.az,
-            instanceType: dbResponse.instanceType,
-            imageId: dbResponse.imageId,
-            launched: dbResponse.launched,
-            terminated: generated,
-            lastEvent: generated,
-          }, transaction);
-          await this.state.removeInstance({region, id}, transaction);
-          log.debug(logInfo, 'CloudWatch Event resulting in deletion');
-        } else {
-          await this.state.updateInstanceState({
-            region,
-            id,
-            state,
-            lastEvent: generated,
-          }, transaction);
-          log.info(logInfo, 'CloudWatch Event resulting in state update');
-        }
-        await this.state.commitTransaction(transaction);
+      });
+      if (wasUpdated) {
+        hlog.info('new state for instance set');
       } else {
-        // While we didn't write anything, we did lock the row and claim a
-        // client.  We should release those
-        await this.state.commitTransaction(transaction);
-
-        this.monitor.count('global.cwe-out-of-order.count', 1);
-        this.monitor.count(`${region}.cwe-out-of-order.count`, 1);
-        // We want to see how big our gaps in out of order delivery are.
-        let delay = dbResponse.lastEvent - generated;
-        this.monitor.measure('global.cwe-out-of-order.delay', delay);
-        this.monitor.measure(`${region}.cwe-out-of-order.delay`, delay);
-        log.info({
-          region,
-          id,
-          state,
-          delay,
-          lastEvent: dbResponse.lastEvent,
-          generated,
-          currentDbState: dbResponse.state,
-        }, 'CloudWatch Event delivered out of order');
-      }
+        hlog.debug('no update to instance state');
+      };
     }
   }
 
@@ -257,21 +206,12 @@ class DeadCloudWatchEventListener extends events.EventEmitter {
     });
   }
 
-  // TODO: Maybe what we should do is store these instance ids in a table and
-  // poll them to see when they do become available and insert them into the
-  // database *then*
   async __handler(msg) {
     let errorMsg = [
-      'UNTRACKED INSTANCE\n\n',
-      'A CloudWatch Event message has failed.  This is likely because the',
-      'EC2 API call to DescribeInstances did not return information.  While',
-      'we do retry this a number of times, we eventually give up.  This instance',
-      'should probably be killed or else deleted.',
-    ].join(' ');
-
-    errorMsg += '\nFailing message follows:\n\n';
-    errorMsg += msg;
-
+      'A CloudWatch Event message has failed too many times.  ',
+      'Failing message follows:\n\n',
+      JSON.stringify(msg),
+    ].join('');
     this.monitor.reportError(new Error(errorMsg), 'info');
   }
 

--- a/lib/housekeeping.js
+++ b/lib/housekeeping.js
@@ -114,11 +114,6 @@ class HouseKeeper {
             } else {
               apiInstanceIds.push(id);
               if (!stateInstanceIds.includes(id)) {
-
-                // Note that unlike the cloud watch event listener, we don't
-                // need to double check the provisioner id field here since we
-                // only get the correct provisioner ids based on the filter
-                // that we're giving to the API
                 await this.state.upsertInstance({
                   workerType,
                   region,

--- a/lib/main.js
+++ b/lib/main.js
@@ -161,6 +161,10 @@ let load = loader({
         }
       }
 
+      if (process.env.FORCE_JS_PG_CLIENT) {
+        client = PG.Client;
+      }
+
       let poolcfg = {
         user,
         password,

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,3 +1,5 @@
+// This lets us have useful aws-sdk stack traces
+Error.stackTraceLimit = 30;
 
 // Standard modules
 const url = require('url');

--- a/lib/main.js
+++ b/lib/main.js
@@ -114,6 +114,7 @@ let load = loader({
           lsChecker: lsChecker,
           pricing,
           tagger,
+          monitor,
         },
         validator: validator,
         authBaseUrl: cfg.taskcluster.authBaseUrl,
@@ -188,10 +189,9 @@ let load = loader({
         log.error({err}, 'Postgres Pool error');
       });
 
-
       // As a best effort, if we're full, we'll start printing the last query
       // executed by each active client
-      setInterval(function () {
+      setInterval(function() {
         try {
           if (pool.waitingCount > 1) {
             currentQueries = pool._clients.map(client => {
@@ -383,13 +383,14 @@ let load = loader({
   },
 
   terminationpoller: {
-    requires: ['ec2', 'cfg', 'runaws', 'state'],
-    setup: async({ec2, cfg, runaws, state}) => {
+    requires: ['ec2', 'cfg', 'runaws', 'state', 'monitor'],
+    setup: async({ec2, cfg, runaws, state, monitor}) => {
       return new TerminationPoller({
         ec2,
         regions: cfg.app.regions,
         runaws,
         state,
+        monitor,
       });
     },
   },

--- a/lib/main.js
+++ b/lib/main.js
@@ -193,9 +193,8 @@ let load = loader({
       // executed by each active client
       setInterval(function () {
         try {
-          if (pool._isFull() || pool.waitingCount > 1) {
+          if (pool.waitingCount > 1) {
             currentQueries = pool._clients.map(client => {
-              console.dir(client);
               return (client._activeQuery || {}).text;
             });
             log.info({currentQueries, waiting: pool.waitingCount}, 'waiting on queries');

--- a/lib/main.js
+++ b/lib/main.js
@@ -188,6 +188,23 @@ let load = loader({
         log.error({err}, 'Postgres Pool error');
       });
 
+
+      // As a best effort, if we're full, we'll start printing the last query
+      // executed by each active client
+      setInterval(function () {
+        try {
+          if (pool._isFull() || pool.waitingCount > 1) {
+            currentQueries = pool._clients.map(client => {
+              console.dir(client);
+              return (client._activeQuery || {}).text;
+            });
+            log.info({currentQueries, waiting: pool.waitingCount}, 'waiting on queries');
+          }
+        } catch (err) {
+
+        }
+      }, 10000);
+
       return pool;
     },
   },

--- a/lib/main.js
+++ b/lib/main.js
@@ -117,7 +117,7 @@ let load = loader({
         },
         validator: validator,
         authBaseUrl: cfg.taskcluster.authBaseUrl,
-        publish: cfg.app.publishMetaData,
+        publish: cfg.app.publishMetadata,
         baseUrl: cfg.server.publicUrl + '/v1',
         referencePrefix: 'ec2-manager/v1/api.json',
         aws: cfg.aws,

--- a/lib/state.js
+++ b/lib/state.js
@@ -234,7 +234,7 @@ class State {
 
     if (client) {
       try {
-        return this._pgpool.query({text: query, values, name});
+        return client.query({text: query, values, name});
       } catch (err) {
         if (rollbackOnError) {
           await this.rollbackTransaction(client);

--- a/lib/state.js
+++ b/lib/state.js
@@ -8,14 +8,14 @@ const crypto = require('crypto');
 
 /* eslint taskcluster/no-for-in: "off" */
 
-const TERMINATION_CODES = {
+const TERMINATION_CODES = Object.freeze({
   clean_shutdown: ['Client.InstanceInitiatedShutdown', 'Client.UserInitiatedShutdown'],
   spot_kill: ['Server.SpotInstanceTermination'],
   insufficient_capacity: ['Server.InsufficientInstanceCapacity'],
   volume_limit_exceeded: ['Client.VolumeLimitExceeded'],
   missing_ami: ['Client.InvalidSnapshot.NotFound'],
   startup_failed: ['Server.InternalError', 'Client.InternalError'],
-};
+});
 
 function _checker(thing, {requiredKeys, allowedKeys, dateKeys}) {
   let allAllowedKeys = [].concat(requiredKeys, allowedKeys);
@@ -1132,4 +1132,4 @@ class State {
   }
 }
 
-module.exports = {State};
+module.exports = {State, TERMINATION_CODES};

--- a/lib/state.js
+++ b/lib/state.js
@@ -239,7 +239,7 @@ class State {
 
     if (client) {
       try {
-        return client.query({text: query, values, name});
+        return await client.query({text: query, values, name});
       } catch (err) {
         if (rollbackOnError) {
           await this.rollbackTransaction(client);
@@ -249,7 +249,7 @@ class State {
       }
     } else {
       try {
-        return this._pgpool.query({text: query, values, name});
+        return await this._pgpool.query({text: query, values, name});
       } catch (err) {
         log.warn({err, query, values}, 'direct query failed');
       }

--- a/lib/state.js
+++ b/lib/state.js
@@ -113,6 +113,7 @@ class State {
   constructor({pgpool, monitor}) {
     this._pgpool = pgpool;
     this._monitor = monitor;
+    this._queryHash = new Map();
   }
 
   /**
@@ -218,7 +219,7 @@ class State {
   // don't need to catch and rethrow everywhere that calls this
   async runQuery({query, values, client, rollbackOnError = true}) {
     assert(typeof query === 'string', 'query must be string');
-    if (typeof values !== 'undefined')) {
+    if (typeof values !== 'undefined') {
       assert(typeof values === 'object', 'values must be an object (array)');
       assert(Array.isArray(values), 'values must be an array');
     }
@@ -226,22 +227,27 @@ class State {
       assert(typeof client === 'object');
     }
     
-    // Wow, this would be a lot of logs
-    log.trace({query, values, usingClient: !!client}, 'running query');
-
-    let name = crypto.createHash('sha1');
+    let name = crypto.createHash('sha1').update(query).digest('hex');
+    if (!this._queryHash.has(name)) {
+      this._queryHash.set(name, query);
+    }
 
     if (client && rollbackOnError) {
       try {
         return this._pgpool.query({text: query, values, name});
       } catch (err) {
-        this.rollbackTransaction(client);
+        if (rollbackOnError) {
+          await this.rollbackTransaction(client);
+        }
+        log.warn({err, query, values}, 'query in transaction failed');
         throw err;
       }
-    } else if (client) {
-      return client.query({text: query, values, name});
     } else {
-      return this._pgpool.query({text: query, values, name});
+      try {
+        return this._pgpool.query({text: query, values, name});
+      } catch (err) {
+        log.warn({err, query, values}, 'direct query failed');
+      }
     }
   }
 
@@ -312,7 +318,7 @@ class State {
       lastEvent,
     } = assertValidInstance(instance);
 
-    let text = [
+    let query = [
       'INSERT INTO instances',
       '(id, "workerType", region, az, "instanceType", state, "imageId", launched, "lastEvent")',
       'VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)',
@@ -330,16 +336,7 @@ class State {
       lastEvent,
     ];
 
-    let name = 'insert-instance';
-
-    let result;
-    if (client) {
-      result = await client.query({text, values, name});
-    } else {
-      result = await this._pgpool.query({text, values, name});
-    }
-
-    assert(result.rowCount === 1, 'inserting instance had incorrect rowCount');
+    let result = await this.runQuery({query, values, client});
   }
 
   /**
@@ -358,7 +355,7 @@ class State {
       lastEvent,
     } = assertValidInstance(instance);
 
-    let text = [
+    let query = [
       'INSERT INTO instances',
       '(id, "workerType", region, az, "instanceType", state, "imageId", launched, "lastEvent")',
       'VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)',
@@ -377,14 +374,7 @@ class State {
       lastEvent,
     ];
 
-    let name = 'upsert-instance';
-
-    let result;
-    if (client) {
-      result = await client.query({text, values, name});
-    } else {
-      result = await this._pgpool.query({text, values, name});
-    }
+    await this.runQuery({query, values, client});
   } 
 
   /**
@@ -397,18 +387,10 @@ class State {
     assert(typeof lastEvent === 'object');
     assert(lastEvent.constructor.name === 'Date');
 
-    let text = 'UPDATE instances SET state = $1, "lastEvent" = $2 WHERE region = $3 AND id = $4';
+    let query = 'UPDATE instances SET state = $1, "lastEvent" = $2 WHERE region = $3 AND id = $4';
     let values = [state, lastEvent, region, id];
-    let name = 'update-instance-state';
     
-    let result;
-    if (client) {
-      result = await client.query({text, values, name});
-    } else {
-      result = await this._pgpool.query({text, values, name});
-    }
-
-    assert(result.rowCount === 1, 'updating instance state had incorrect rowCount');
+    await this.runQuery({query, values, client});
   }
 
   /**
@@ -418,18 +400,10 @@ class State {
     assert(typeof region === 'string');
     assert(typeof id === 'string');
 
-    let text = 'DELETE FROM instances WHERE id = $1 AND region = $2';
+    let query = 'DELETE FROM instances WHERE id = $1 AND region = $2';
     let values =[id, region];
-    let name = 'remove-instance';
-
-    let result;
-    if (client) {
-      result = await client.query({text, values, name});
-    } else {
-      result = await this._pgpool.query({values, text, name});
-    }
-
-    return result.rowCount;
+    
+    await this.runQuery({query, values, client});
   }
   
   /**
@@ -450,7 +424,7 @@ class State {
       lastEvent,
     } = assertValidTermination(termination);
 
-    let text = [
+    let query = [
       'INSERT INTO terminations',
       '(id, "workerType", region, az, "instanceType", "imageId", code, reason, launched, terminated, "lastEvent")',
       'VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)',
@@ -470,16 +444,7 @@ class State {
       lastEvent,
     ];
 
-    let name = 'insert-termination';
-
-    let result;
-    if (client) {
-      result = await client.query({text, values, name});
-    } else {
-      result = await this._pgpool.query({text, values, name});
-    }
-
-    assert(result.rowCount === 1, 'inserting termination had incorrect rowCount');
+    await this.runQuery({query, values, client});
   }
 
   /**
@@ -500,7 +465,7 @@ class State {
       lastEvent,
     } = assertValidTermination(termination);
 
-    let text = [
+    let query = [
       'INSERT INTO terminations',
       '(id, "workerType", region, az, "instanceType", "imageId", code, reason, launched, terminated, "lastEvent")',
       'VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)',
@@ -524,14 +489,7 @@ class State {
       lastEvent,
     ];
 
-    let name = 'upsert-termination';
-
-    let result;
-    if (client) {
-      result = await client.query({text, values, name});
-    } else {
-      result = await this._pgpool.query({text, values, name});
-    }
+    await this.runQuery({query, values, client});
   } 
 
   /**
@@ -549,30 +507,23 @@ class State {
     assert(typeof lastEvent === 'object', 'incorrect lastEvent type');
     assert(lastEvent.constructor.name === 'Date', 'lastEvent is not a Date');
 
-    let text;
+    let query;
     let values;
     let name;
 
     if (terminated) { 
-      text = 'UPDATE terminations SET code = $1, reason = $2, terminated = $3, "lastEvent" = $4';
-      text += ' WHERE region = $5 AND id = $6;';
+      query = 'UPDATE terminations SET code = $1, reason = $2, terminated = $3, "lastEvent" = $4';
+      query += ' WHERE region = $5 AND id = $6;';
       values = [code, reason, terminated, lastEvent, region, id];
       name = 'update-termination-state-with-termination-time';
     } else {
-      text = 'UPDATE terminations SET code = $1, reason = $2, "lastEvent" = $3';
-      text += ' WHERE region = $4 AND id = $5;';
+      query = 'UPDATE terminations SET code = $1, reason = $2, "lastEvent" = $3';
+      query += ' WHERE region = $4 AND id = $5;';
       values = [code, reason, lastEvent, region, id];
       name = 'update-termination-state-without-termination-time';
     }
-    
-    let result;
-    if (client) {
-      result = await client.query({text, values, name});
-    } else {
-      result = await this._pgpool.query({text, values, name});
-    }
 
-    assert(result.rowCount === 1, 'updating termination state had incorrect rowCount');
+    await this.runQuery({query, values, client});
   }
 
   /**
@@ -582,18 +533,10 @@ class State {
     assert(typeof region === 'string');
     assert(typeof id === 'string');
 
-    let text = 'DELETE FROM terminations WHERE id = $1 AND region = $2';
+    let query = 'DELETE FROM terminations WHERE id = $1 AND region = $2';
     let values =[id, region];
-    let name = 'remove-termination';
 
-    let result;
-    if (client) {
-      result = await client.query({text, values, name});
-    } else {
-      result = await this._pgpool.query({values, text, name});
-    }
-
-    return result.rowCount;
+    await this.runQuery({query, values, client});
   }
   
   /**
@@ -603,7 +546,7 @@ class State {
   async reportAmiUsage({region, id}, client) {
     assert(typeof region === 'string');
     assert(typeof id === 'string');
-    let text = [
+    let query = [
       'INSERT INTO amiusage (region, id, "lastUsed")',
       'VALUES ($1, $2, now())',
       'ON CONFLICT (region, id) DO UPDATE SET "lastUsed" = EXCLUDED."lastUsed"',
@@ -611,13 +554,7 @@ class State {
     
     let values = [region, id];
     
-    let result;
-    if (client) {
-      result = await client.query({text, values, name: 'upsert-amiusage'});
-    } else {
-      result = await this._pgpool.query({text, values, name: 'upsert-amiusage'});
-    }
-    assert(result.rowCount === 1, 'upserting AMI usage had incorrect rowCount');
+    await this.runQuery({query, values, client});
   }
 
   /**
@@ -685,7 +622,7 @@ class State {
 
     query += ';';
 
-    return {text: query, values: values};
+    return {query, values: values};
   }
 
   /**
@@ -693,7 +630,7 @@ class State {
    *
    * NOTE: NOT SAFE FOR USE WITH USER PROVIDED CONDITION OR TABLE NAMES
    */
-  async _listTable({table, conditions = {}, limit}, client = undefined) {
+  async _listTable({table, conditions = {}, limit}, client) {
     assert(typeof table === 'string');
     assert(typeof conditions === 'object');
     if (limit) {
@@ -705,14 +642,9 @@ class State {
     // We want a FOR UPDATE query if a client is passed in because the only
     // reason to pass in a client for a query is to lock the rows as part of a
     // transaction!
-    let {text, values} = this._generateTableListQuery(table, conditions, client ? true : false, limit);
+    let {query, values} = this._generateTableListQuery(table, conditions, client ? true : false, limit);
 
-    let result;
-    if (client) {
-      result = await client.query({text, values});
-    } else {
-      result = await this._pgpool.query({text, values});
-    }
+    let result = await this.runQuery({query, values, client});
 
     return result.rows || [];
   }
@@ -722,7 +654,7 @@ class State {
    *
    * NOTE: NOT SAFE FOR USE WITH USER PROVIDED CONDITION NAMES
    */
-  async listInstances(conditions = {}, client = undefined) {
+  async listInstances(conditions = {}, client) {
     assert(typeof conditions === 'object');
     return this._listTable({table: 'instances', conditions}, client);
   }
@@ -732,7 +664,7 @@ class State {
    *
    * NOTE: NOT SAFE FOR USE WITH USER PROVIDED CONDITION NAMES
    */
-  async listTerminations(conditions = {}, client = undefined) {
+  async listTerminations(conditions = {}, client) {
     assert(typeof conditions === 'object');
     return this._listTable({table: 'terminations', conditions}, client);
   }
@@ -741,22 +673,17 @@ class State {
    * Get a list of terminations which need to be polled.  Since this will likely
    * involve table-level locking, we'll get terminations for all regions
    */
-  async findTerminationsToPoll(count, client = undefined) {
+  async findTerminationsToPoll(count, client) {
     assert(typeof count === 'number');
 
-    let text = [
+    let query = [
       'SELECT id, region FROM terminations',
       'WHERE code IS NULL AND reason IS NULL AND terminated > now() - interval \'1h\'',
       'LIMIT $1',
     ].join(' ');
     let values = [count];
 
-    let result;
-    if (client) {
-      result = await client.query({text, values});
-    } else {
-      result = await this._pgpool.query({text, values});
-    }
+    let result = await this.runQuery({query, values, client});
 
     return result.rows || [];
   }
@@ -766,7 +693,7 @@ class State {
    *
    * NOTE: NOT SAFE FOR USE WITH USER PROVIDED CONDITION NAMES
    */
-  async listAmiUsage(conditions = {}, client = undefined) {
+  async listAmiUsage(conditions = {}, client) {
     assert(typeof conditions === 'object');
     return this._listTable({table: 'amiusage', conditions}, client);
   }
@@ -774,7 +701,7 @@ class State {
   /**
   * Get a list of the current EBS volume usage
   */
-  async listEbsUsage(conditions = {}, client = undefined) {
+  async listEbsUsage(conditions = {}, client) {
     assert(typeof conditions === 'object');
     return this._listTable('ebsusage', conditions, client);
   }
@@ -788,60 +715,38 @@ class State {
   async instanceCounts({workerType}, client) {
     assert(typeof workerType === 'string');
 
-    let shouldReleaseClient = false;
-    if (!client) {
-      shouldReleaseClient = true;
-      client = await this._pgpool.connect();
-    }
+    let query = [
+      'SELECT state, "instanceType", count("instanceType") FROM instances',
+      'WHERE "workerType" = $1 AND (state = \'pending\' OR state = \'running\')',
+      'GROUP BY state, "instanceType"',
+    ].join(' ');
+
+    let values = [workerType];
+
+    let result = await this.runQuery({query, values, client});
 
     let counts = {pending: [], running: []};
 
-    await client.query('BEGIN');
-    try {
-      let instanceQuery = [
-        'SELECT state, "instanceType", count("instanceType") FROM instances',
-        'WHERE "workerType" = $1 AND (state = \'pending\' OR state = \'running\')',
-        'GROUP BY state, "instanceType"',
-      ].join(' ');
-      let instancesResult = await client.query({text: instanceQuery, values: [workerType]});
-
-      await client.query('COMMIT');
-
-      for (let row of instancesResult.rows) {
-        let list;
-        switch (row.state) {
-          case 'running':
-            list = counts.running;
-            break;
-          default:
-            list = counts.pending;
-            break;
-        }
-        list.push({instanceType: row.instanceType, count: row.count, type: 'instance'});
+    for (let row of result.rows) {
+      let list;
+      if (row.state === 'running') {
+        list = counts.running;
+      } else {
+        list = counts.pending;
       }
-
-      return counts;
-    } catch (err) {
-      client.query('ROLLBACK');
-      throw err;
-    } finally {
-      if (shouldReleaseClient) {
-        client.release();
-      }
+      list.push({instanceType: row.instanceType, count: row.count, type: 'instance'});
     }
+
+    return counts;
   }
 
   async listWorkerTypes(client) {
-    let text = [
+    let query = [
       'SELECT DISTINCT "workerType" FROM instances',
       'ORDER BY "workerType";',
     ].join(' ');
-    let result;
-    if (client) {
-      result = await client.query(text);
-    } else {
-      result = await this._pgpool.query(text);
-    }
+
+    let result = await this.runQuery({query, client});
     return result.rows.map(x => x.workerType);
   }
 
@@ -851,31 +756,14 @@ class State {
    */
   async listIdsOfWorkerType({workerType}, client) {
 
-    let shouldReleaseClient = false;
-    if (!client) {
-      shouldReleaseClient = true;
-      client = await this._pgpool.connect();
-    } 
+    let result = await this.listInstances({workerType}, client);
 
-    await client.query('BEGIN');
+    return {instanceIds: result.map(x => {
+      return {region: x.region, id: x.id};
+    })};
 
-    try {
-      let instances = await this.listInstances({workerType}, client);
-      // Let's find *all* the instance-ids
-      let instanceIds = instances.map(x => {
-        return {region: x.region, id: x.id};
-      });
-      await client.query('COMMIT');
-      return {instanceIds};
-    } catch (err) {
-      await client.query('ROLLBACK');
-    } finally {
-      if (shouldReleaseClient) {
-        client.release();
-      }
-    }
   }
-
+    
   /**
    * Log a request to AWS services
    */
@@ -963,11 +851,13 @@ class State {
     values[durIdx] = duration;
     vals[durIdx] = `$${durIdx + 1} * interval '1 us'`;
 
-    let text = `INSERT INTO awsrequests (${columns.map(x => `"${x}"`).join(', ')}) `;
-    text += ` VALUES (${vals.join(', ')}) `;
-    text += 'ON CONFLICT DO NOTHING;';
-
-    return await this._pgpool.query({text, values});
+    let query = [
+      `INSERT INTO awsrequests (${columns.map(x => `"${x}"`).join(', ')})`,
+      `VALUES (${vals.join(', ')})`,
+      'ON CONFLICT DO NOTHING;',
+    ].join(' ');
+    
+    return this.runQuery({query, values});
   }
 
   /**
@@ -975,7 +865,7 @@ class State {
    *
    * NOTE: NOT SAFE FOR USE WITH USER PROVIDED CONDITION NAMES
    */
-  async listAWSRequests(conditions = {}, client = undefined) {
+  async listAWSRequests(conditions = {}, client) {
     assert(typeof conditions === 'object');
     return this._listTable({table: 'awsrequests', conditions}, client);
   }
@@ -1015,10 +905,9 @@ class State {
 
     query.push('GROUP BY region, az, "instanceType";');
 
-    let result = await this._pgpool.query({
-      text: query.join(' '),
-      values,
-    });
+    query = query.join(' ');
+
+    let result = await this.runQuery({query, values});
 
     return result.rows || [];
   }
@@ -1079,10 +968,9 @@ class State {
       'ORDER BY region, az, "instanceType";',
     ]);
 
-    let result = await this._pgpool.query({
-      text: query.join(' '),
-      values,
-    });
+    query = query.join(' ');
+
+    let result = await this.runQuery({query, values});
 
     return result.rows || [];
   }
@@ -1116,10 +1004,9 @@ class State {
       'ORDER BY region, az, "instanceType";',
     ]);
 
-    let result = await this._pgpool.query({
-      text: query.join(' '),
-      values,
-    });
+    query = query.join(' ');
+
+    let result = await this.runQuery({query, values});
 
     return result.rows || [];
   }
@@ -1205,10 +1092,9 @@ class State {
       values.push(workerType);
     }
 
-    let result = await this._pgpool.query({
-      text: query.join(' '),
-      values,
-    });
+    query = query.join(' ');
+
+    let result = await this.runQuery({query, values});
 
     return result.rows || [];
   }
@@ -1220,26 +1106,15 @@ class State {
     assert(typeof generated === 'object');
     assert(generated.constructor.name === 'Date');
 
-    let text = [
+    let query = [
       'INSERT INTO cloudwatchlog (id, region, state, generated)',
-      'VALUES ($1, $2, $3, $4);',
+      'VALUES ($1, $2, $3, $4)',
+      'ON CONFLICT DO NOTHING;',
     ].join(' ');
+
     let values = [id, region, state, generated];
-    let name = 'insert-cloud-watch-log';
 
-    let result;
-    try {
-      result = await this._pgpool.query({text, values, name});
-    } catch (err) {
-      // We're going to ignore this primary key violation because it's a sign
-      // that a message has already been handled by this system.  Since this is
-      // a second receiption of the message we don't really want to log it
-      if (err.sqlState !== '23505') {
-        throw err;
-      }
-    }
-
-    assert(result.rowCount === 1, 'logging cloud watch event had incorrect rowCount');
+    await this.runQuery({query, values});
   }
 }
 

--- a/lib/state.js
+++ b/lib/state.js
@@ -218,11 +218,14 @@ class State {
   // rollback to happen if there's an error in the query execution, so that we
   // don't need to catch and rethrow everywhere that calls this
   async runQuery({query, values, client, rollbackOnError = true}) {
+
     assert(typeof query === 'string', 'query must be string');
+
     if (typeof values !== 'undefined') {
       assert(typeof values === 'object', 'values must be an object (array)');
       assert(Array.isArray(values), 'values must be an array');
     }
+
     if (client) {
       assert(typeof client === 'object');
     }
@@ -231,6 +234,8 @@ class State {
     if (!this._queryHash.has(name)) {
       this._queryHash.set(name, query);
     }
+
+    log.info({query, values, inTransaction: !!client}, 'running query');
 
     if (client) {
       try {

--- a/lib/state.js
+++ b/lib/state.js
@@ -4,6 +4,7 @@ const which = require('which');
 const path = require('path');
 const {spawn} = require('child_process');
 const log = require('./log');
+const crypto = require('crypto');
 
 /* eslint taskcluster/no-for-in: "off" */
 
@@ -209,6 +210,39 @@ class State {
         }
       });
     });
+  }
+
+  // Run a query.  Query should be a parameterized string.  Values is a list of
+  // parameters for the query.  rollbackOnError (default: true) will cause a
+  // rollback to happen if there's an error in the query execution, so that we
+  // don't need to catch and rethrow everywhere that calls this
+  async runQuery({query, values, client, rollbackOnError = true}) {
+    assert(typeof query === 'string', 'query must be string');
+    if (typeof values !== 'undefined')) {
+      assert(typeof values === 'object', 'values must be an object (array)');
+      assert(Array.isArray(values), 'values must be an array');
+    }
+    if (client) {
+      assert(typeof client === 'object');
+    }
+    
+    // Wow, this would be a lot of logs
+    log.trace({query, values, usingClient: !!client}, 'running query');
+
+    let name = crypto.createHash('sha1');
+
+    if (client && rollbackOnError) {
+      try {
+        return this._pgpool.query({text: query, values, name});
+      } catch (err) {
+        this.rollbackTransaction(client);
+        throw err;
+      }
+    } else if (client) {
+      return client.query({text: query, values, name});
+    } else {
+      return this._pgpool.query({text: query, values, name});
+    }
   }
 
   /**

--- a/lib/state.js
+++ b/lib/state.js
@@ -232,7 +232,7 @@ class State {
       this._queryHash.set(name, query);
     }
 
-    if (client && rollbackOnError) {
+    if (client) {
       try {
         return this._pgpool.query({text: query, values, name});
       } catch (err) {

--- a/lib/state.js
+++ b/lib/state.js
@@ -235,7 +235,7 @@ class State {
       this._queryHash.set(name, query);
     }
 
-    log.info({query, values, inTransaction: !!client}, 'running query');
+    log.debug({query, values, inTransaction: !!client}, 'running query');
 
     if (client) {
       try {

--- a/lib/state.js
+++ b/lib/state.js
@@ -380,7 +380,7 @@ class State {
   } 
 
   /**
-   * Update an instance's state.
+   * Update an instance's state.  Return true if an update occured
    */
   async updateInstanceState({region, id, state, lastEvent}, client) {
     assert(typeof region === 'string');
@@ -389,10 +389,16 @@ class State {
     assert(typeof lastEvent === 'object');
     assert(lastEvent.constructor.name === 'Date');
 
-    let query = 'UPDATE instances SET state = $1, "lastEvent" = $2 WHERE region = $3 AND id = $4';
+    let query = [
+      'UPDATE instances',
+      'SET state = $1, "lastEvent" = $2',
+      'WHERE region = $3 AND id = $4 AND "lastEvent" < $2',
+    ].join(' ');
+
     let values = [state, lastEvent, region, id];
     
-    await this.runQuery({query, values, client});
+    let result = await this.runQuery({query, values, client});
+    return result.rowCount === 1;
   }
 
   /**

--- a/lib/state.js
+++ b/lib/state.js
@@ -359,7 +359,9 @@ class State {
       'INSERT INTO instances',
       '(id, "workerType", region, az, "instanceType", state, "imageId", launched, "lastEvent")',
       'VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)',
-      'ON CONFLICT (region, id) DO UPDATE SET state = EXCLUDED.state;',
+      'ON CONFLICT (region, id) DO',
+      'UPDATE SET state = EXCLUDED.state',
+      'WHERE instances."lastEvent" IS NULL OR instances."lastEvent" < EXCLUDED."lastEvent";',
     ].join(' ');
 
     let values = [
@@ -473,6 +475,7 @@ class State {
       'code = EXCLUDED.code, ',
       'reason = EXCLUDED.reason, ',
       'terminated = EXCLUDED.terminated',
+      'WHERE terminations."lastEvent" IS NULL OR terminations."lastEvent" < EXCLUDED."lastEvent";',
     ].join(' ');
 
     let values = [

--- a/lib/termination-poller.js
+++ b/lib/termination-poller.js
@@ -3,20 +3,24 @@ const {runAWSRequest} = require('./aws-request');
 const Iterate = require('taskcluster-lib-iterate');
 const log = require('./log');
 
+const {TERMINATION_CODES} = require('./state');
+
 const INSTANCE_LIMIT = 200;
 const POLL_DELAY = 30;
 
 class TerminationPoller {
-  constructor({ec2, regions, runaws = runAWSRequest, pollDelay = POLL_DELAY, state}) {
+  constructor({ec2, regions, runaws = runAWSRequest, pollDelay = POLL_DELAY, state, monitor}) {
     assert(typeof ec2 === 'object');
     assert(Array.isArray(regions));
     regions.forEach(region => assert(typeof region === 'string'));
     assert(typeof state === 'object');
+    assert(typeof monitor === 'object');
 
     this.ec2 = ec2;
     this.regions = regions;
     this.state = state;
     this.runaws = runaws;
+    this.monitor = monitor;
 
     this.iterator = new Iterate({
       maxIterationTime: 60 * 15,
@@ -31,6 +35,7 @@ class TerminationPoller {
         }
       },
     });
+
   }
 
   start() {
@@ -84,20 +89,75 @@ class TerminationPoller {
       for (let reservation of result.Reservations || []) {
         for (let instance of reservation.Instances || []) {
           if (instance.StateReason && instance.StateReason.Code && instance.StateReason.Message) {
-            let m = instance.StateReason.Message;
-            let c = instance.StateReason.Code;
-            if (m.slice(0, c.length + 2) === c + ': ') {
-              m = m.slice(c.length + 2);
+            let msg = instance.StateReason.Message;
+            let code = instance.StateReason.Code;
+            if (msg.slice(0, code.length + 2) === code + ': ') {
+              msg = msg.slice(code.length + 2);
             }
             resolutions.push({
               region,
               id: instance.InstanceId,
-              code: c,
-              reason: m,
+              code: code,
+              reason: msg,
               lastEvent,
             });
+
+            // We want to measure each termination code's regularity
+
+            // NOTE: Ideally we'd be using the database to get these values,
+            // but that would require an otherwise unneeded query to the DB to
+            // get these values.  Since these values are set in the
+            // ec2-manager, we know.  As a result, we'll just grab the data out
+            // of the underlying instance object returned by the EC2 api.  Be
+            // forewarned, those who change how these values are set up
+            let workerType = 'unknown-worker-type';
+            for (let tag of instance.Tags || []) {
+              if (tag.Key === 'Name') {
+                workerType = tag.Value;
+              }
+            }
+            let instanceType = instance.InstanceType;
+            let codeType;
+            if (code in TERMINATION_CODES.clean_shutdown) {
+              codeType = 'clean';
+            } else {
+              codeType = 'exceptional';
+              let errMsg = [
+                `THIS IS A WORKER TYPE CONFIGURATION ISSUE OF ${workerType} OR `,
+                `AN EC2 SERVICE DISRUPTION IN ${region}/${instanceType}!!!  `,
+                'This report is part of the normal operation of EC2-Manager ',
+                `and is not a bug: ${code}: ${msg}`,
+              ];
+              this.monitor.reportError(new Error(errMsg.join('')), 'info', {
+                workerType,
+                instanceType,
+                region,
+              });
+            }
+            let groupings = [
+              'overall',
+              'instance-type.' + instance.InstanceType,
+              'worker-type.' + workerType,
+              'region.' + region,
+            ].map(x => `termination-code.${codeType}.${code}.${x}`);
+            for (let grouping of groupings) {
+              this.monitor.count(grouping);
+            }
           } else {
             log.info({instance, region}, 'found terminated instance without code or reason');
+            // We want to report *something* to say that we weren't able to find a code or reason
+            // for the shutdown
+            let errMsg = [
+              `THIS IS A WORKER TYPE CONFIGURATION ISSUE OF ${workerType} OR `,
+              `AN EC2 SERVICE DISRUPTION IN ${region}/${instanceType}!!!  `,
+              'This report is part of the normal operation of EC2-Manager ',
+              'and is not a bug: unable to determine error code or reason for termination',
+            ];
+            this.monitor.reportError(new Error(errMsg.join('')), 'info', {
+              workerType,
+              instanceType,
+              region,
+            });
           }
         }
       }

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -55,6 +55,7 @@ describe('Api', () => {
   });
 
   afterEach(() => {
+    assume(state._pgpool.waitingCount).equals(0);
     server.terminate();
     sandbox.restore();
   });

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -44,6 +44,7 @@ describe('Api', () => {
   });
 
   beforeEach(async() => {
+    state = await main('state', {profile: 'test', process: 'test'});
     await state._runScript('clear-db.sql');
     runaws = sandbox.stub();
     server = await main('server', {profile: 'test', process: 'test', runaws});

--- a/test/cloud-watch-event-listener_test.js
+++ b/test/cloud-watch-event-listener_test.js
@@ -67,6 +67,7 @@ describe('Cloud Watch Event Listener', () => {
   // rather not have that be so easy to call by mistake in real code
   beforeEach(async() => {
     await state._runScript('clear-db.sql');
+    state = await main('state', {profile: 'test', process: 'test'});
     sandbox.stub(tagger, 'runaws');
   });
 

--- a/test/cloud-watch-event-listener_test.js
+++ b/test/cloud-watch-event-listener_test.js
@@ -72,7 +72,20 @@ describe('Cloud Watch Event Listener', () => {
 
   afterEach(() => {
     sandbox.restore();
-    assume(state._pgpool.waitingCount).equals(0);
+    // Make sure we're not dropping client references
+    for (let client of state._pgpool._clients) {
+      try {
+        client.release();
+        let lastQuery = (client._activeQuery || {}).text;
+        let err = new Error('Leaked a client that last executed: ' + lastQuery);
+        err.client = client;
+        throw err;
+      } catch (err) {
+        if (!/Release called on client which has already been released to the pool/.exec(err.message)) {
+          throw err;
+        }
+      }
+    }
   });
 
   it('should handle pending message', async() => {

--- a/test/cloud-watch-event-listener_test.js
+++ b/test/cloud-watch-event-listener_test.js
@@ -72,6 +72,7 @@ describe('Cloud Watch Event Listener', () => {
 
   afterEach(() => {
     sandbox.restore();
+    assume(state._pgpool.waitingCount).equals(0);
   });
 
   it('should handle pending message', async() => {

--- a/test/housekeeping_test.js
+++ b/test/housekeeping_test.js
@@ -39,6 +39,7 @@ describe('House Keeper', () => {
   });
 
   beforeEach(async() => {
+    state = await main('state', {profile: 'test', process: 'test'});
     monitor = await main('monitor', {profile: 'test', process: 'test'});
     await state._runScript('clear-db.sql');
 

--- a/test/state_test.js
+++ b/test/state_test.js
@@ -1,4 +1,3 @@
-
 const main = require('../lib/main');
 const assume = require('assume');
 const uuid = require('uuid');
@@ -75,14 +74,14 @@ describe('State', () => {
     let table = 'junk';
 
     it('no conditions', () => {
-      let expected = {text: 'SELECT * FROM junk;', values: []};
+      let expected = {query: 'SELECT * FROM junk;', values: []};
       let actual = db._generateTableListQuery(table);
       assume(expected).deeply.equals(actual);
     });
 
     it('one flat condition', () => {
       let expected = {
-        text: 'SELECT * FROM junk WHERE junk."a" = $1;',
+        query: 'SELECT * FROM junk WHERE junk."a" = $1;',
         values: ['aye'],
       };
       let actual = db._generateTableListQuery(table, {a: 'aye'});
@@ -91,7 +90,7 @@ describe('State', () => {
 
     it('two flat conditions', () => {
       let expected = {
-        text: 'SELECT * FROM junk WHERE junk."a" = $1 AND junk."b" = $2;',
+        query: 'SELECT * FROM junk WHERE junk."a" = $1 AND junk."b" = $2;',
         values: ['aye', 'bee'],
       };
       let actual = db._generateTableListQuery(table, {a: 'aye', b: 'bee'});
@@ -100,7 +99,7 @@ describe('State', () => {
 
     it('one list condition', () => {
       let expected = {
-        text: 'SELECT * FROM junk WHERE junk."a" = $1 OR junk."a" = $2 OR junk."a" = $3;',
+        query: 'SELECT * FROM junk WHERE junk."a" = $1 OR junk."a" = $2 OR junk."a" = $3;',
         values: ['a', 'b', 'c'],
       };
       let actual = db._generateTableListQuery(table, {a: ['a', 'b', 'c']});
@@ -109,7 +108,7 @@ describe('State', () => {
 
     it('two list conditions', () => {
       let expected = {
-        text: 'SELECT * FROM junk WHERE (junk."a" = $1 OR junk."a" = $2) AND (junk."b" = $3 OR junk."b" = $4);',
+        query: 'SELECT * FROM junk WHERE (junk."a" = $1 OR junk."a" = $2) AND (junk."b" = $3 OR junk."b" = $4);',
         values: ['a', 'b', 'c', 'd'],
       };
       let actual = db._generateTableListQuery(table, {a: ['a', 'b'], b: ['c', 'd']});
@@ -118,7 +117,7 @@ describe('State', () => {
 
     it('mixed type flat-list-flat conditions', () => {
       let expected = {
-        text: 'SELECT * FROM junk WHERE junk."a" = $1 AND (junk."b" = $2 OR junk."b" = $3) AND junk."c" = $4;',
+        query: 'SELECT * FROM junk WHERE junk."a" = $1 AND (junk."b" = $2 OR junk."b" = $3) AND junk."c" = $4;',
         values: ['a', 'b', 'c', 'd'],
       };
       let actual = db._generateTableListQuery(table, {a: 'a', b: ['b', 'c'], c: 'd'});
@@ -127,7 +126,7 @@ describe('State', () => {
 
     it('limits', () => {
       let expected = {
-        text: 'SELECT * FROM junk WHERE junk."a" = $1 AND (junk."b" = $2 OR junk."b" = $3) AND junk."c" = $4 LIMIT 1;',
+        query: 'SELECT * FROM junk WHERE junk."a" = $1 AND (junk."b" = $2 OR junk."b" = $3) AND junk."c" = $4 LIMIT 1;',
         values: ['a', 'b', 'c', 'd'],
       };
       let actual = db._generateTableListQuery(table, {a: 'a', b: ['b', 'c'], c: 'd'}, undefined, 1);
@@ -136,7 +135,7 @@ describe('State', () => {
 
     it('null conditions', () => {
       let expected = {
-        text: 'SELECT * FROM junk WHERE junk."a" IS NULL AND (junk."b" IS NULL);',
+        query: 'SELECT * FROM junk WHERE junk."a" IS NULL AND (junk."b" IS NULL);',
         values: [],
       };
       let actual = db._generateTableListQuery(table, {a: null, b: [null]});
@@ -146,6 +145,7 @@ describe('State', () => {
   });
 
   it('should be able to filter AMI usages', async() => {
+    debugger;
     let result = await db.listAmiUsage();
     assume(result).has.length(0);
     await db.reportAmiUsage({region: defaultInst.region, id: defaultInst.imageId});

--- a/test/state_test.js
+++ b/test/state_test.js
@@ -196,6 +196,20 @@ describe('State', () => {
     assume(instances[0]).has.property('state', secondState);
   });
 
+  it('should update instance state and only change the state if the new state is newer', async() => {
+    await db.insertInstance(Object.assign({}, defaultInst, {lastEvent: new Date(3600 * 1000), state: 'running'}));
+    assume(await db.listInstances()).has.length(1);
+    await db.updateInstanceState({
+      region: defaultInst.region,
+      id: defaultInst.id,
+      state: 'pending',
+      lastEvent: new Date(0),
+    });
+    let instances = await db.listInstances();
+    assume(instances).has.lengthOf(1);
+    assume(instances[0]).has.property('state', 'running');
+  });
+
   it('should be able to insert a complete termination', async() => {
     delete defaultTerm.code;
     delete defaultTerm.reason;

--- a/test/state_test.js
+++ b/test/state_test.js
@@ -47,6 +47,11 @@ describe('State', () => {
     };
   });
 
+  afterEach(() => {
+    // Make sure we're not dropping client references
+    assume(db._pgpool.waitingCount).equals(0);
+  });
+
   describe('type parsers', () => {
     it('should parse ints (20) to js ints', async() => {
       let result = await db._pgpool.query('SELECT count(id) FROM instances;');

--- a/test/state_test.js
+++ b/test/state_test.js
@@ -68,17 +68,17 @@ describe('State', () => {
 
   // NOTE that the afterEach hook here that checks for leaked clients is
   // critical!
-  describe.only('running queries', () => {
+  describe('running queries', () => {
 
-    beforeEach(async () => {
+    beforeEach(async() => {
+      await db.runQuery({query: 'DROP TABLE IF EXISTS a;'});
       await db.runQuery({query: 'CREATE TABLE a (b TEXT PRIMARY KEY)'});
       await db.runQuery({query: 'INSERT INTO a VALUES (\'hi\')'});
     });
 
-    afterEach(async () => {
-      await db.runQuery({query: 'DROP TABLE a;'});
+    afterEach(async() => {
+      await db.runQuery({query: 'DROP TABLE IF EXISTS a;'});
     });
-
 
     it('should work', async() => {
       let result = await db.runQuery({query: 'SELECT now();'});
@@ -94,8 +94,8 @@ describe('State', () => {
       await db.commitTransaction(tx);
     });
 
-    it('should be able to handle multiple concurrent transactions', async() => {
-      await Promise.all([...Array(1000).keys()].map(async () => {
+    it.skip('should be able to handle multiple concurrent transactions', async() => {
+      await Promise.all([...Array(1000).keys()].map(async() => {
         let tx = await db.beginTransaction();
         await db.runQuery({query: 'SELECT * FROM a FOR UPDATE', client: tx});
         await db.runQuery({query: 'INSERT INTO a VALUES ($1)', values: [uuid.v4()], client: tx});

--- a/test/state_test.js
+++ b/test/state_test.js
@@ -166,6 +166,15 @@ describe('State', () => {
     assume(await db.listInstances()).has.length(1);
   });
 
+  it('should upsert an instance and only change the state if the new state is newer', async() => {
+    await db.insertInstance(Object.assign({}, defaultInst, {lastEvent: new Date(3600 * 1000), state: 'running'}));
+    assume(await db.listInstances()).has.length(1);
+    await db.upsertInstance(Object.assign({}, defaultInst, {lastEvent: new Date(0), state: 'pending'}));
+    let instances = await db.listInstances();
+    assume(instances).has.lengthOf(1);
+    assume(instances[0]).has.property('state', 'running');
+  });
+
   it('should be able to update an instance', async() => {
     let firstState = 'pending';
     let secondState = 'running';

--- a/test/termination-poller_test.js
+++ b/test/termination-poller_test.js
@@ -63,6 +63,7 @@ describe('TerminationPoller', () => {
       state,
       runaws: describeInstancesStub,
       regions: cfg.app.regions,
+      monitor,
     });
 
   });


### PR DESCRIPTION
Let's give up on the `.promise()` feature of the aws-sdk, it's more trouble than it's worth.  This patch makes it so that we're using the older style `.send()` and even listeners way of calling APIs.  There's also a change to timeout much quicker now, since almost all EC2 apis are called inside of tc-lib-api event handlers and those *must* be 30s or less.