### PR TITLE
spell publishMetaData the jonas way

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -115,7 +115,7 @@ let load = loader({
         },
         validator: validator,
         authBaseUrl: cfg.taskcluster.authBaseUrl,
-        publish: cfg.app.publishMetaData,
+        publish: cfg.app.publishMetadata,
         baseUrl: cfg.server.publicUrl + '/v1',
         referencePrefix: 'ec2-manager/v1/api.json',
         aws: cfg.aws,


### PR DESCRIPTION
It's spelled this way in `main.js`