### PR TITLE
Make taskcluster-client-web linting pass

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -586,7 +586,7 @@ api.declare({
         'region: string',
         'volumetype: string',
         'lastused: timestamp',
-      ].join('\n\t'),
+      ].join('\n  '),
       '}',
     ].join('\n'),
 }, async function(req, res) {
@@ -618,7 +618,7 @@ api.declare({
       [
         'Lists current EBS volume usage by returning a list of objects',
         'that are uniquely defined by {region, volumetype, state} in the form:',
-      ].join(' '),
+      ].join('\n'),
       '{',
       [
         'region: string,',
@@ -627,7 +627,7 @@ api.declare({
         'totalcount: integer,',
         'totalgb: integer,',
         'touched: timestamp (last time that information was updated),',
-      ].join('\n\t'),
+      ].join('\n  '),
       '}',
     ].join('\n'),
 }, async function(req, res) {


### PR DESCRIPTION
The tabs are making the lines too long in `taskcluster-client-web`. I need to have this patch merged before I can start implementing the UI for the awesomeness that @jhford created.