### PR TITLE
Fix to provide a real baseUrl in api.json

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -60,6 +60,7 @@ production:
     env: production
     forceSSL: true
     trustProxy: true
+    publicUrl: 'https://ec2-manager.taskcluster.net/'
     baseUrl: 'https://ec2-manager.taskcluster.net/v1'
   app:
     id: 'ec2-manager-production'


### PR DESCRIPTION
Without this change, it is providing "localhost:5555/v1" as the baseUrl.