### PR TITLE
Bug 1428068: Handle EC2 prices endpoint pagination

### DIFF
--- a/lib/pricing-poller.js
+++ b/lib/pricing-poller.js
@@ -135,44 +135,57 @@ class PricingPoller {
 
     for (let region of this.regions) {
       let ec2 = this.ec2[region];
-      let [azResult, priceResult] = await Promise.all([
-        this.runaws(ec2, 'describeAvailabilityZones', {
-          Filters: [{
-            Name: 'state',
-            Values: ['available'],
-          }],
-        }),
-        this.runaws(ec2, 'describeSpotPriceHistory', {
+      let nextToken = undefined;
+      let azResult = await this.runaws(ec2, 'describeAvailabilityZones', {
+        Filters: [{
+          Name: 'state',
+          Values: ['available'],
+        }],
+      });
+      let zones = azResult.AvailabilityZones.map(x => x.ZoneName);
+
+      do {
+        const requestParams = {
           StartTime: startTime,
           Filters: [{
             Name: 'product-description',
             Values: ['Linux/UNIX'],
           }],
-        }),
-      ]);
+        };
+        if (nextToken) {
+          requestParams.NextToken = nextToken;
+        }
 
-      // Get the information from the API responses that we care about
-      let zones = azResult.AvailabilityZones.map(x => x.ZoneName);
-      let pricePoints = priceResult.SpotPriceHistory.filter(x => zones.includes(x.AvailabilityZone));
+        let priceResult = await this.runaws(
+          ec2,
+          'describeSpotPriceHistory',
+          requestParams
+        );
 
-      // Determine what the prices which the API described.
-      let spotPrices = this._findSpotPricesForRegion({pricePoints});
-      let onDemandPrices = this._findOnDemandPricesForRegion();
+        nextToken = priceResult.NextToken;
 
-      // Add some information to the spot prices
-      spotPrices = spotPrices.map(x => {
-        Object.assign(x, {type: 'spot', region});
-        return x;
-      });
+        // Get the information from the API responses that we care about
+        let pricePoints = priceResult.SpotPriceHistory.filter(x => zones.includes(x.AvailabilityZone));
 
-      // Add some information to the on-demand prices
-      onDemandPrices = onDemandPrices.map(x => {
-        Object.assign(x, {type: 'ondemand', region});
-        return x;
-      });
+        // Determine what the prices which the API described.
+        let spotPrices = this._findSpotPricesForRegion({pricePoints});
+        let onDemandPrices = this._findOnDemandPricesForRegion();
 
-      Array.prototype.push.apply(prices, spotPrices);
-      Array.prototype.push.apply(prices, onDemandPrices);
+        // Add some information to the spot prices
+        spotPrices = spotPrices.map(x => {
+          Object.assign(x, {type: 'spot', region});
+          return x;
+        });
+
+        // Add some information to the on-demand prices
+        onDemandPrices = onDemandPrices.map(x => {
+          Object.assign(x, {type: 'ondemand', region});
+          return x;
+        });
+
+        Array.prototype.push.apply(prices, spotPrices);
+        Array.prototype.push.apply(prices, onDemandPrices);
+      } while (nextToken);
     }
 
     prices.sort((a, b) => {


### PR DESCRIPTION
The DescribeSpotPriceHistory endpoint returns a field call NextToken
that, if not null, indicates there are additional data to fetch.

On next call, NextToken should be an input parameters to tell the server
we are fetching the remaining data.

Notice it had to move DescribeAvailabilityZones out of the loop because
it doesn't do pagination.