### PR TITLE
Bug 1541042 - Terminate instance shows Internal Server Error

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -423,7 +423,7 @@ builder.declare({
   try {
     await req.authorize({region, instanceId, hasWorkerType: false});
   } catch (err) {
-    if (err.code !== 'AuthorizationError') {
+    if (err.code === 'AuthorizationError') {
       throw err;
     }
     let workerTypes = await this.state.listInstances({id: instanceId, region});


### PR DESCRIPTION
From https://github.com/taskcluster/ec2-manager/blob/4554b53c545629d27ce67e20fe8569406aa5147c/lib/api.js#L399-L405

A user with `ec2-manager:manage-resources:<workerType>` is currently not able to terminate an instance. This is probably because the status code is not 'AuthorizationError` and so it was throwing early instead of running https://github.com/taskcluster/ec2-manager/blob/4554b53c545629d27ce67e20fe8569406aa5147c/lib/api.js#L434.